### PR TITLE
Allow sending new email notifications for incoming emails only

### DIFF
--- a/lib/account.js
+++ b/lib/account.js
@@ -400,6 +400,7 @@ class Account {
             .del(`${REDIS_PREFIX}ial:${this.account}`) // mailbox list
             .del(`${REDIS_PREFIX}iah:${this.account}`) // mailbox list for ID references
             .del(`${REDIS_PREFIX}iar:b:${this.account}`) // bounce list
+            .del(`${REDIS_PREFIX}iar:s:${this.account}`) // seen messages list
             .del(`${REDIS_PREFIX}iaq:${this.account}`) // delayed message queue
             .del(`${REDIS_PREFIX}iat:${this.account}`) // access tokens
             .exec();

--- a/lib/mailbox.js
+++ b/lib/mailbox.js
@@ -190,6 +190,10 @@ class Mailbox {
         return `${REDIS_PREFIX}iar:b:${this.connection.account}`;
     }
 
+    getSeenMessagesKey() {
+        return `${REDIS_PREFIX}iar:s:${this.connection.account}`;
+    }
+
     startIdle() {
         if (!this.isSelected() || this.imapClient.idling) {
             return;
@@ -554,6 +558,9 @@ class Mailbox {
                 });
             }
         }
+
+        // check if we have seen this message before or not (approximate estimation, not 100% exact)
+        messageInfo.seemsLikeNew = !!(await this.connection.redis.pfadd(this.getSeenMessagesKey(), messageInfo.emailId || messageInfo.messageId));
 
         await this.connection.notify(this, MESSAGE_NEW_NOTIFY, messageInfo);
         if (bounceNotifyInfo) {

--- a/lib/routes-ui.js
+++ b/lib/routes-ui.js
@@ -62,7 +62,8 @@ const configWebhooksSchema = {
     headersAll: Joi.boolean().truthy('Y', 'true', '1', 'on').falsy('N', 'false', 0, '').default(false),
     notifyHeaders: Joi.string().empty('').trim(),
     notifyText: Joi.boolean().truthy('Y', 'true', '1', 'on').falsy('N', 'false', 0, '').default(false),
-    notifyTextSize: Joi.number().empty('')
+    notifyTextSize: Joi.number().empty(''),
+    inboxNewOnly: Joi.boolean().truthy('Y', 'true', '1', 'on').falsy('N', 'false', 0, '').default(false)
 };
 
 for (let type of notificationTypes) {
@@ -492,6 +493,7 @@ function applyRoutes(server, call) {
             const webhookEvents = (await settings.get('webhookEvents')) || [];
             const notifyText = (await settings.get('notifyText')) || false;
             const notifyTextSize = Number(await settings.get('notifyTextSize')) || 0;
+            const inboxNewOnly = (await settings.get('inboxNewOnly')) || false;
 
             let webhooksEnabled = await settings.get('webhooksEnabled');
             let values = {
@@ -499,6 +501,7 @@ function applyRoutes(server, call) {
                 webhooks: (await settings.get('webhooks')) || '',
 
                 notifyAll: webhookEvents.includes('*'),
+                inboxNewOnly,
 
                 headersAll: notifyHeaders.includes('*'),
                 notifyHeaders: notifyHeaders
@@ -515,7 +518,9 @@ function applyRoutes(server, call) {
                     menuConfig: true,
                     menuConfigWebhooks: true,
 
-                    notificationTypes: notificationTypes.map(type => Object.assign({}, type, { checked: webhookEvents.includes(type.name) })),
+                    notificationTypes: notificationTypes.map(type =>
+                        Object.assign({}, type, { checked: webhookEvents.includes(type.name), isMessageNew: type.name === 'messageNew' })
+                    ),
 
                     values
                 },
@@ -536,6 +541,7 @@ function applyRoutes(server, call) {
                     webhooks: request.payload.webhooks,
                     notifyText: request.payload.notifyText,
                     notifyTextSize: request.payload.notifyTextSize || 0,
+                    inboxNewOnly: request.payload.inboxNewOnly,
 
                     webhookEvents: notificationTypes.filter(type => !!request.payload[`notify_${type.name}`]).map(type => type.name),
                     notifyHeaders: (request.payload.notifyHeaders || '')
@@ -551,6 +557,7 @@ function applyRoutes(server, call) {
                 if (request.payload.notifyAll) {
                     data.webhookEvents.push('*');
                 }
+
                 if (request.payload.headersAll) {
                     data.notifyHeaders.push('*');
                 }
@@ -572,7 +579,9 @@ function applyRoutes(server, call) {
                         menuConfig: true,
                         menuConfigWebhooks: true,
 
-                        notificationTypes: notificationTypes.map(type => Object.assign({}, type, { checked: !!request.payload[`notify_${type.name}`] }))
+                        notificationTypes: notificationTypes.map(type =>
+                            Object.assign({}, type, { checked: !!request.payload[`notify_${type.name}`], isMessageNew: type.name === 'messageNew' })
+                        )
                     },
                     {
                         layout: 'app'
@@ -610,7 +619,11 @@ function applyRoutes(server, call) {
                                 menuConfigWebhooks: true,
 
                                 notificationTypes: notificationTypes.map(type =>
-                                    Object.assign({}, type, { checked: !!request.payload[`notify_${type.name}`], error: errors[`notify_${type.name}`] })
+                                    Object.assign({}, type, {
+                                        checked: !!request.payload[`notify_${type.name}`],
+                                        isMessageNew: type.name === 'messageNew',
+                                        error: errors[`notify_${type.name}`]
+                                    })
                                 ),
 
                                 errors

--- a/lib/schemas.js
+++ b/lib/schemas.js
@@ -42,6 +42,11 @@ const settingsSchema = {
         .falsy('N', 'false', 0, '')
         .description('If true, then rewrite html links in sent emails to track opens and clicks'),
 
+    inboxNewOnly: Joi.boolean()
+        .truthy('Y', 'true', '1', 'on')
+        .falsy('N', 'false', 0, '')
+        .description('If true, then send "New Email" webhooks for incoming emails only'),
+
     serviceSecret: Joi.string().allow('').example('verysecr8t').description('HMAC secret for signing public requests').label('ServiceSecret'),
 
     authServer: Joi.string()

--- a/views/config/webhooks.hbs
+++ b/views/config/webhooks.hbs
@@ -114,6 +114,24 @@
                         title="&quot;{{name}}&quot;">{{description}}</label>
                     {{#if error}}<span class="invalid-feedback">{{error}}</span>{{/if}}
                 </div>
+
+                {{#if isMessageNew}}
+
+                <div style="padding-left: 20px;">
+                    <div class="text-muted float-right code-link">[<a href="/admin/iframe/docs#/settings/postV1Settings"
+                            target="_blank">inboxNewOnly</a>]
+                    </div>
+                    <input type="checkbox" class="form-check-input {{#if error}}is-invalid{{/if}}" id="inboxNewOnly"
+                        name="inboxNewOnly" {{#if ../values.inboxNewOnly}}checked{{/if}}>
+                    <label class="form-check-label" for="inboxNewOnly">Send "New Email" notifications about incoming
+                        emails
+                        only</label>
+                    {{#if ../errors.inboxNewOnly}}
+                    <span class="invalid-feedback">{{../errors.inboxNewOnly}}</span>
+                    {{/if}}
+                </div>
+
+                {{/if}}
                 {{/each}}
             </div>
         </div>


### PR DESCRIPTION
* Added new configuration option `"inboxNewOnly"`. If it is true, then send `messageNew` webhooks _only_ for messages from the INBOX
* `messageNew` webhooks include new property `seemsLikeNew`. It is an approximation if EmailEngine has processed this email before or not. Not 100% correct (should be around 98% certainty).