### PR TITLE
Fix misspelling of authentication

### DIFF
--- a/views/layout/app.hbs
+++ b/views/layout/app.hbs
@@ -232,7 +232,7 @@
                                             <span class="icon text-white-50">
                                                 <i class="fas fa-arrow-right"></i>
                                             </span>
-                                            <span class="text">Enable authenction</span>
+                                            <span class="text">Enable authentication</span>
                                         </a>
                                     </div>
                                 </div>


### PR DESCRIPTION
Hi,

This is a very minor fix to correct the misspelling of the word 'authentication':

![image](https://user-images.githubusercontent.com/40571193/167638654-c76824b4-0be5-489c-9fc5-5695d13c635c.png)

Thanks.