### PR TITLE
Added option to enable support for mail.ru OAuth2

### DIFF
--- a/lib/routes-ui.js
+++ b/lib/routes-ui.js
@@ -31,7 +31,6 @@ const nodeFetch = require('node-fetch');
 const fetchCmd = global.fetch || nodeFetch;
 
 const { DEFAULT_MAX_LOG_LINES, PDKDF2_ITERATIONS, PDKDF2_SALT_SIZE, PDKDF2_DIGEST, LOGIN_PERIOD_TTL, DEFAULT_PAGE_SIZE, REDIS_PREFIX } = require('./consts');
-const { request } = require('http');
 
 const LICENSE_HOST = 'https://postalsys.com';
 
@@ -790,7 +789,8 @@ function applyRoutes(server, call) {
                 enableTokens: !(await settings.get('disableTokens')),
                 enableApiProxy: (await settings.get('enableApiProxy')) || false,
                 trackSentMessages: (await settings.get('trackSentMessages')) || false,
-                labsDocumentStore: (await settings.get('labsDocumentStore')) || false
+                labsDocumentStore: (await settings.get('labsDocumentStore')) || false,
+                labsMailRu: (await settings.get('labsMailRu')) || (await settings.get('mailRuEnabled')) || false
             };
 
             return h.view(
@@ -822,7 +822,8 @@ function applyRoutes(server, call) {
                     disableTokens: !request.payload.enableTokens,
                     enableApiProxy: request.payload.enableApiProxy,
                     trackSentMessages: request.payload.trackSentMessages,
-                    labsDocumentStore: request.payload.labsDocumentStore
+                    labsDocumentStore: request.payload.labsDocumentStore,
+                    labsMailRu: request.payload.labsMailRu
                 };
 
                 try {
@@ -842,6 +843,10 @@ function applyRoutes(server, call) {
 
                 if (!data.labsDocumentStore && (await settings.get('documentStoreEnabled'))) {
                     await settings.set('documentStoreEnabled', false);
+                }
+
+                if (!data.labsDocumentStore && (await settings.get('mailRuEnabled'))) {
+                    await settings.set('mailRuEnabled', false);
                 }
 
                 await request.flash({ type: 'info', message: `Configuration updated` });
@@ -917,6 +922,11 @@ function applyRoutes(server, call) {
                         .truthy('Y', 'true', '1', 'on')
                         .falsy('N', 'false', 0, '')
                         .description('If true, then allow using the Document Store')
+                        .default(false),
+                    labsMailRu: Joi.boolean()
+                        .truthy('Y', 'true', '1', 'on')
+                        .falsy('N', 'false', 0, '')
+                        .description('If true, then allow using Mail.ru OAuth2')
                         .default(false),
                     enableTokens: Joi.boolean().truthy('Y', 'true', '1', 'on').falsy('N', 'false', 0, '').default(false)
                 })
@@ -1316,8 +1326,6 @@ function applyRoutes(server, call) {
                     activeOutlook: values.provider === 'outlook',
                     activeMailRu: values.provider === 'mailRu',
 
-                    mailRuEnabled: await settings.get('mailRuEnabled'),
-
                     providerName: values.provider.replace(/^./, c => c.toUpperCase()),
 
                     hasClientSecret,
@@ -1445,8 +1453,6 @@ function applyRoutes(server, call) {
                         activeOutlook: request.payload.provider === 'outlook',
                         activeMailRu: request.payload.provider === 'mailRu',
 
-                        mailRuEnabled: await settings.get('mailRuEnabled'),
-
                         providerName: request.payload.provider.replace(/^./, c => c.toUpperCase()),
 
                         defaultRedirectUrl,
@@ -1498,8 +1504,6 @@ function applyRoutes(server, call) {
                                 activeGmailService: request.payload.provider === 'gmailService',
                                 activeOutlook: request.payload.provider === 'outlook',
                                 activeMailRu: request.payload.provider === 'mailRu',
-
-                                mailRuEnabled: await settings.get('mailRuEnabled'),
 
                                 providerName: request.payload.provider.replace(/^./, c => c.toUpperCase()),
 

--- a/views/accounts/register/index.hbs
+++ b/views/accounts/register/index.hbs
@@ -44,7 +44,7 @@
     {{/if}}
 
 
-    {{#if mailRuEnableds}}
+    {{#if mailRuEnabled}}
     <div class="mb-3">
         <form method="post" action="/accounts/new">
             <input type="hidden" name="crumb" value="{{crumb}}">

--- a/views/config/oauth.hbs
+++ b/views/config/oauth.hbs
@@ -21,9 +21,10 @@
     </li>
 
     <!-- Do not expose Mail.RU by default (untested) -->
-    {{#if mailRuEnabled}}
+    {{#if showMailRu}}
     <li class="nav-item">
-        <a class="nav-link {{#if activeMailRu}}active{{/if}}" href="/admin/config/oauth/mailRu">Mail.ru</a>
+        <a class="nav-link {{#if activeMailRu}}active{{/if}}" href="/admin/config/oauth/mailRu">Mail.ru <span
+                class="badge badge-dark">beta</span></a>
     </li>
     {{/if}}
 
@@ -66,6 +67,10 @@
                     <li><code>"userinfo"</code>
                     <li><code>"mail.imap"</code>
                 </ul>
+
+                <div class="alert alert-info"><strong>NB!</strong> The required "mail.imap" scope might not be available
+                    for your <a href="https://oauth.mail.ru/app/" target="_blank">OAuth2 apps</a>
+                    by default.</div>
                 {{/if}}
 
             </div>

--- a/views/config/service.hbs
+++ b/views/config/service.hbs
@@ -238,6 +238,19 @@
                     (ElasticSearch). Enabling this option will add a new configuration menu option you can
                     use to set up document store syncing.</small>
             </div>
+
+            <div class="form-group form-check">
+                <input type="checkbox" class="form-check-input {{#if errors.labsMailRu}}is-invalid{{/if}}"
+                    id="labsMailRu" name="labsMailRu" {{#if values.labsMailRu}}checked{{/if}} />
+                <label class="form-check-label" for="labsMailRu">Allow to use OAuth2 with Mail.ru</label>
+                {{#if errors.labsMailRu}}
+                <span class="invalid-feedback">{{errors.labsMailRu}}</span>
+                {{/if}}
+                <small class="form-text text-muted"><a href="https://oauth.mail.ru/docs" target="_blank">OAuth2 for
+                        Mail.ru</a> is disabled by default due to insufficient
+                    testing. It might or might not work as intended. Make sure that your OAuth2 app has the required
+                    email scopes.</small>
+            </div>
         </div>
     </div>
 

--- a/workers/api.js
+++ b/workers/api.js
@@ -5064,7 +5064,8 @@ When making API calls remember that requests against the same account are queued
                 systemAlerts,
                 embeddedTemplateHeader: await settings.get('templateHeader'),
                 currentYear: new Date().getFullYear(),
-                showDocumentStore: (await settings.get('labsDocumentStore')) || (await settings.get('documentStoreEnabled'))
+                showDocumentStore: (await settings.get('labsDocumentStore')) || (await settings.get('documentStoreEnabled')),
+                showMailRu: (await settings.get('labsMailRu')) || (await settings.get('mailRuEnabled'))
             };
         }
     });


### PR DESCRIPTION
- Added option to the labs section to enable OAuth2 for Mail.ru. It is not enabled by default due to insufficient testing.