### PR TITLE
Allow reading ENV values from files with key_FILE=path

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ on:
     push:
         branches:
             - master
-            - feature-templates-ui
+            - feature-env-file
 
 name: Deploy test instance
 

--- a/lib/db.js
+++ b/lib/db.js
@@ -21,7 +21,26 @@ config.dbs = config.dbs || {
 const { Queue } = require('bullmq');
 const Redis = require('ioredis');
 
-const redisConf = process.env.EENGINE_REDIS || process.env.REDIS_URL || config.dbs.redis;
+// duplicat function declaration to avoid requireing tools.js
+const readEnvValue = key => {
+    if (key in process.env) {
+        return process.env[key];
+    }
+
+    if (typeof process.env[`${key}_FILE`] === 'string' && process.env[`${key}_FILE`]) {
+        try {
+            // try to load from file
+            process.env[key] = fs.readFileSync(process.env[`${key}_FILE`], 'utf-8');
+            logger.trace({ msg: 'Loaded environment value from file', key, file: process.env[`${key}_FILE`] });
+        } catch (err) {
+            logger.error({ msg: 'Failed to load environment value from file', key, file: process.env[`${key}_FILE`], err });
+            process.env[key] = '';
+        }
+        return process.env[key];
+    }
+};
+
+const redisConf = readEnvValue('EENGINE_REDIS') || readEnvValue('REDIS_URL') || config.dbs.redis;
 const REDIS_CONF = Object.assign(
     {
         // some defaults

--- a/lib/get-secret.js
+++ b/lib/get-secret.js
@@ -7,17 +7,37 @@ if (!process.env.EE_ENV_LOADED) {
 
 const config = require('wild-config');
 const vault = require('node-vault');
+const fs = require('fs');
 const logger = require('./logger');
 
 config.service = config.service || {};
 
-const ENCRYPT_SECRET = process.env.EENGINE_SECRET || config.service.secret;
+// duplicat function declaration to avoid requireing tools.js
+const readEnvValue = key => {
+    if (key in process.env) {
+        return process.env[key];
+    }
 
-const VAULT_ADDR = process.env.VAULT_ADDR;
-const VAULT_ROLE_ID = process.env.VAULT_ROLE_ID;
-const VAULT_SECRET_ID = process.env.VAULT_SECRET_ID;
-const VAULT_PATH = process.env.VAULT_PATH;
-const VAULT_KEY = process.env.VAULT_KEY || 'secret';
+    if (typeof process.env[`${key}_FILE`] === 'string' && process.env[`${key}_FILE`]) {
+        try {
+            // try to load from file
+            process.env[key] = fs.readFileSync(process.env[`${key}_FILE`], 'utf-8');
+            logger.trace({ msg: 'Loaded environment value from file', key, file: process.env[`${key}_FILE`] });
+        } catch (err) {
+            logger.error({ msg: 'Failed to load environment value from file', key, file: process.env[`${key}_FILE`], err });
+            process.env[key] = '';
+        }
+        return process.env[key];
+    }
+};
+
+const ENCRYPT_SECRET = readEnvValue('EENGINE_SECRET') || config.service.secret;
+
+const VAULT_ADDR = readEnvValue('VAULT_ADDR');
+const VAULT_ROLE_ID = readEnvValue('VAULT_ROLE_ID');
+const VAULT_SECRET_ID = readEnvValue('VAULT_SECRET_ID');
+const VAULT_PATH = readEnvValue('VAULT_PATH');
+const VAULT_KEY = readEnvValue('VAULT_KEY') || 'secret';
 
 const vaultClient =
     VAULT_ADDR && VAULT_ROLE_ID && VAULT_SECRET_ID && VAULT_PATH

--- a/lib/routes-ui.js
+++ b/lib/routes-ui.js
@@ -6,7 +6,7 @@ const settings = require('./settings');
 const tokens = require('./tokens');
 const Joi = require('joi');
 const logger = require('./logger');
-const { failAction, verifyAccountInfo, getLogs, flattenObjectKeys, getStats, getBoolean, getSignedFormData } = require('./tools');
+const { failAction, verifyAccountInfo, getLogs, flattenObjectKeys, getStats, getBoolean, getSignedFormData, readEnvValue } = require('./tools');
 const packageData = require('../package.json');
 const he = require('he');
 const crypto = require('crypto');
@@ -595,9 +595,9 @@ function applyRoutes(server, call) {
         method: 'GET',
         path: '/admin/upgrade',
         async handler(request, h) {
-            const isDO = getBoolean(process.env.EENGINE_DOCEAN);
-            const isScriptInstalled = getBoolean(process.env.EENGINE_INSTALL_SCRIPT);
-            const isRender = typeof process.env.RENDER_SERVICE_SLUG === 'string' && process.env.RENDER_SERVICE_SLUG;
+            const isDO = getBoolean(readEnvValue('EENGINE_DOCEAN'));
+            const isScriptInstalled = getBoolean(readEnvValue('EENGINE_INSTALL_SCRIPT'));
+            const isRender = typeof readEnvValue('RENDER_SERVICE_SLUG') === 'string' && readEnvValue('RENDER_SERVICE_SLUG');
             const isGeneral = !isDO && !isRender && !isScriptInstalled;
 
             return h.view(

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -20,7 +20,8 @@ const { parentPort } = require('worker_threads');
 const { PassThrough } = require('stream');
 const socks = require('socks');
 const os = require('os');
-const fs = require('fs').promises;
+const Fs = require('fs');
+const fs = Fs.promises;
 const pathlib = require('path');
 const { compare: compareVersions, validate: validateVersion } = require('compare-versions');
 const { REDIS_PREFIX } = require('./consts');
@@ -1203,5 +1204,27 @@ MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEV3QUiYsp13nD9suD1/ZkEXnuMoSg
         }
 
         return false;
+    },
+
+    hasEnvValue(key) {
+        return key in process.env || `${key}_FILE` in process.env;
+    },
+
+    readEnvValue(key) {
+        if (key in process.env) {
+            return process.env[key];
+        }
+
+        if (typeof process.env[`${key}_FILE`] === 'string' && process.env[`${key}_FILE`]) {
+            try {
+                // try to load from file
+                process.env[key] = Fs.readFileSync(process.env[`${key}_FILE`], 'utf-8');
+                logger.trace({ msg: 'Loaded environment value from file', key, file: process.env[`${key}_FILE`] });
+            } catch (err) {
+                logger.error({ msg: 'Failed to load environment value from file', key, file: process.env[`${key}_FILE`], err });
+                process.env[key] = '';
+            }
+            return process.env[key];
+        }
     }
 };

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
         "@postalsys/templates": "1.0.0",
         "ace-builds": "1.6.0",
         "bull-arena": "3.29.3",
-        "bullmq": "1.86.1",
+        "bullmq": "1.86.2",
         "compare-versions": "4.1.3",
         "dotenv": "16.0.1",
         "encoding-japanese": "2.0.0",

--- a/scan.js
+++ b/scan.js
@@ -7,12 +7,13 @@ const Redis = require('ioredis');
 const redisUrl = require('./lib/redis-url');
 const packageData = require('./package.json');
 const { threadId } = require('worker_threads');
+const { readEnvValue } = require('./lib/tools');
 
 config.dbs = config.dbs || {
     redis: 'redis://127.0.0.1:6379/8'
 };
 
-const redisConf = process.env.EENGINE_REDIS || process.env.REDIS_URL || config.dbs.redis;
+const redisConf = readEnvValue('EENGINE_REDIS') || readEnvValue('REDIS_URL') || config.dbs.redis;
 const REDIS_CONF = Object.assign(
     {
         // some defaults

--- a/workers/api.js
+++ b/workers/api.js
@@ -6,10 +6,26 @@ const packageData = require('../package.json');
 const config = require('wild-config');
 const logger = require('../lib/logger');
 
+const {
+    getByteSize,
+    getDuration,
+    getStats,
+    flash,
+    failAction,
+    verifyAccountInfo,
+    isEmail,
+    getLogs,
+    getWorkerCount,
+    normalizePath,
+    unpackUIDRangeForSearch,
+    matcher,
+    readEnvValue
+} = require('../lib/tools');
+
 const Bugsnag = require('@bugsnag/js');
-if (process.env.BUGSNAG_API_KEY) {
+if (readEnvValue('BUGSNAG_API_KEY')) {
     Bugsnag.start({
-        apiKey: process.env.BUGSNAG_API_KEY,
+        apiKey: readEnvValue('BUGSNAG_API_KEY'),
         appVersion: packageData.version,
         logger: {
             debug(...args) {
@@ -59,20 +75,6 @@ const { templates } = require('../lib/templates');
 const { redis, REDIS_CONF, notifyQueue, documentsQeueue } = require('../lib/db');
 const { Account } = require('../lib/account');
 const settings = require('../lib/settings');
-const {
-    getByteSize,
-    getDuration,
-    getStats,
-    flash,
-    failAction,
-    verifyAccountInfo,
-    isEmail,
-    getLogs,
-    getWorkerCount,
-    normalizePath,
-    unpackUIDRangeForSearch,
-    matcher
-} = require('../lib/tools');
 
 const getSecret = require('../lib/get-secret');
 const { getESClient } = require('../lib/document-store');
@@ -117,13 +119,14 @@ config.api = config.api || {
 
 config.service = config.service || {};
 
-const EENGINE_TIMEOUT = getDuration(process.env.EENGINE_TIMEOUT || config.service.commandTimeout) || DEFAULT_EENGINE_TIMEOUT;
-const MAX_ATTACHMENT_SIZE = getByteSize(process.env.EENGINE_MAX_SIZE || config.api.maxSize) || DEFAULT_MAX_ATTACHMENT_SIZE;
+const EENGINE_TIMEOUT = getDuration(readEnvValue('EENGINE_TIMEOUT') || config.service.commandTimeout) || DEFAULT_EENGINE_TIMEOUT;
+const MAX_ATTACHMENT_SIZE = getByteSize(readEnvValue('EENGINE_MAX_SIZE') || config.api.maxSize) || DEFAULT_MAX_ATTACHMENT_SIZE;
 
-const API_PORT = (process.env.EENGINE_PORT && Number(process.env.EENGINE_PORT)) || (process.env.PORT && Number(process.env.PORT)) || config.api.port;
-const API_HOST = process.env.EENGINE_HOST || config.api.host;
+const API_PORT =
+    (readEnvValue('EENGINE_PORT') && Number(readEnvValue('EENGINE_PORT'))) || (readEnvValue('PORT') && Number(readEnvValue('PORT'))) || config.api.port;
+const API_HOST = readEnvValue('EENGINE_HOST') || config.api.host;
 
-const IMAP_WORKER_COUNT = getWorkerCount(process.env.EENGINE_WORKERS || (config.workers && config.workers.imap)) || 4;
+const IMAP_WORKER_COUNT = getWorkerCount(readEnvValue('EENGINE_WORKERS') || (config.workers && config.workers.imap)) || 4;
 
 const TRACKER_IMAGE = Buffer.from('R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7', 'base64');
 

--- a/workers/documents.js
+++ b/workers/documents.js
@@ -5,10 +5,12 @@ const { parentPort } = require('worker_threads');
 const packageData = require('../package.json');
 const logger = require('../lib/logger');
 
+const { readEnvValue } = require('../lib/tools');
+
 const Bugsnag = require('@bugsnag/js');
-if (process.env.BUGSNAG_API_KEY) {
+if (readEnvValue('BUGSNAG_API_KEY')) {
     Bugsnag.start({
-        apiKey: process.env.BUGSNAG_API_KEY,
+        apiKey: readEnvValue('BUGSNAG_API_KEY'),
         appVersion: packageData.version,
         logger: {
             debug(...args) {

--- a/workers/imap.js
+++ b/workers/imap.js
@@ -5,10 +5,12 @@ const packageData = require('../package.json');
 const config = require('wild-config');
 const logger = require('../lib/logger');
 
+const { getDuration, getBoolean, emitChangeEvent, readEnvValue, hasEnvValue } = require('../lib/tools');
+
 const Bugsnag = require('@bugsnag/js');
-if (process.env.BUGSNAG_API_KEY) {
+if (readEnvValue('BUGSNAG_API_KEY')) {
     Bugsnag.start({
-        apiKey: process.env.BUGSNAG_API_KEY,
+        apiKey: readEnvValue('BUGSNAG_API_KEY'),
         appVersion: packageData.version,
         logger: {
             debug(...args) {
@@ -34,7 +36,6 @@ const { MessagePortWritable } = require('../lib/message-port-stream');
 const settings = require('../lib/settings');
 const msgpack = require('msgpack5')();
 
-const { getDuration, getBoolean, emitChangeEvent } = require('../lib/tools');
 const getSecret = require('../lib/get-secret');
 
 config.service = config.service || {};
@@ -43,9 +44,9 @@ config.log = config.log || {
     raw: false
 };
 
-const EENGINE_LOG_RAW = 'EENGINE_LOG_RAW' in process.env ? getBoolean(process.env.EENGINE_LOG_RAW) : getBoolean(config.log.raw);
+const EENGINE_LOG_RAW = hasEnvValue('EENGINE_LOG_RAW') ? getBoolean(readEnvValue('EENGINE_LOG_RAW')) : getBoolean(config.log.raw);
 const DEFAULT_EENGINE_TIMEOUT = 10 * 1000;
-const EENGINE_TIMEOUT = getDuration(process.env.EENGINE_TIMEOUT || config.service.commandTimeout) || DEFAULT_EENGINE_TIMEOUT;
+const EENGINE_TIMEOUT = getDuration(readEnvValue('EENGINE_TIMEOUT') || config.service.commandTimeout) || DEFAULT_EENGINE_TIMEOUT;
 
 const DEFAULT_STATES = {
     init: 0,

--- a/workers/smtp.js
+++ b/workers/smtp.js
@@ -6,10 +6,12 @@ const packageData = require('../package.json');
 const config = require('wild-config');
 const logger = require('../lib/logger');
 
+const { getDuration, emitChangeEvent, readEnvValue } = require('../lib/tools');
+
 const Bugsnag = require('@bugsnag/js');
-if (process.env.BUGSNAG_API_KEY) {
+if (readEnvValue('BUGSNAG_API_KEY')) {
     Bugsnag.start({
-        apiKey: process.env.BUGSNAG_API_KEY,
+        apiKey: readEnvValue('BUGSNAG_API_KEY'),
         appVersion: packageData.version,
         logger: {
             debug(...args) {
@@ -32,7 +34,6 @@ const { SMTPServer } = require('smtp-server');
 const util = require('util');
 const { redis } = require('../lib/db');
 const { Account } = require('../lib/account');
-const { getDuration, emitChangeEvent } = require('../lib/tools');
 const getSecret = require('../lib/get-secret');
 const { Splitter, Joiner } = require('mailsplit');
 const { HeadersRewriter } = require('../lib/headers-rewriter');
@@ -51,7 +52,7 @@ config.service = config.service || {};
 const MAX_SIZE = 20 * 1024 * 1024;
 const DEFAULT_EENGINE_TIMEOUT = 10 * 1000;
 
-const EENGINE_TIMEOUT = getDuration(process.env.EENGINE_TIMEOUT || config.service.commandTimeout) || DEFAULT_EENGINE_TIMEOUT;
+const EENGINE_TIMEOUT = getDuration(readEnvValue('EENGINE_TIMEOUT') || config.service.commandTimeout) || DEFAULT_EENGINE_TIMEOUT;
 
 const ACCOUNT_CACHE = new WeakMap();
 

--- a/workers/submit.js
+++ b/workers/submit.js
@@ -6,10 +6,12 @@ const packageData = require('../package.json');
 const config = require('wild-config');
 const logger = require('../lib/logger');
 
+const { getDuration, readEnvValue } = require('../lib/tools');
+
 const Bugsnag = require('@bugsnag/js');
-if (process.env.BUGSNAG_API_KEY) {
+if (readEnvValue('BUGSNAG_API_KEY')) {
     Bugsnag.start({
-        apiKey: process.env.BUGSNAG_API_KEY,
+        apiKey: readEnvValue('BUGSNAG_API_KEY'),
         appVersion: packageData.version,
         logger: {
             debug(...args) {
@@ -32,7 +34,6 @@ const util = require('util');
 const { redis, notifyQueue, queueConf } = require('../lib/db');
 const { Worker } = require('bullmq');
 const { Account } = require('../lib/account');
-const { getDuration } = require('../lib/tools');
 const getSecret = require('../lib/get-secret');
 const settings = require('../lib/settings');
 const msgpack = require('msgpack5')();
@@ -52,9 +53,9 @@ config.service = config.service || {};
 
 const DEFAULT_EENGINE_TIMEOUT = 10 * 1000;
 
-const EENGINE_TIMEOUT = getDuration(process.env.EENGINE_TIMEOUT || config.service.commandTimeout) || DEFAULT_EENGINE_TIMEOUT;
+const EENGINE_TIMEOUT = getDuration(readEnvValue('EENGINE_TIMEOUT') || config.service.commandTimeout) || DEFAULT_EENGINE_TIMEOUT;
 
-const SUBMIT_QC = (process.env.EENGINE_SUBMIT_QC && Number(process.env.EENGINE_SUBMIT_QC)) || config.queues.submit || 1;
+const SUBMIT_QC = (readEnvValue('EENGINE_SUBMIT_QC') && Number(readEnvValue('EENGINE_SUBMIT_QC'))) || config.queues.submit || 1;
 
 let callQueue = new Map();
 let mids = 0;

--- a/workers/webhooks.js
+++ b/workers/webhooks.js
@@ -6,10 +6,12 @@ const packageData = require('../package.json');
 const config = require('wild-config');
 const logger = require('../lib/logger');
 
+const { readEnvValue } = require('../lib/tools');
+
 const Bugsnag = require('@bugsnag/js');
-if (process.env.BUGSNAG_API_KEY) {
+if (readEnvValue('BUGSNAG_API_KEY')) {
     Bugsnag.start({
-        apiKey: process.env.BUGSNAG_API_KEY,
+        apiKey: readEnvValue('BUGSNAG_API_KEY'),
         appVersion: packageData.version,
         logger: {
             debug(...args) {
@@ -42,7 +44,7 @@ config.queues = config.queues || {
     notify: 1
 };
 
-const NOTIFY_QC = (process.env.EENGINE_NOTIFY_QC && Number(process.env.EENGINE_NOTIFY_QC)) || config.queues.notify || 1;
+const NOTIFY_QC = (readEnvValue('EENGINE_NOTIFY_QC') && Number(readEnvValue('EENGINE_NOTIFY_QC'))) || config.queues.notify || 1;
 
 function getAccountKey(account) {
     return `iad:${account}`;


### PR DESCRIPTION
* If environment variable `KEY` is not set but there is `KEY_FILE` then try to read the value from the referenced path as the value for that environment key

```
$ echo 'secretpass' > /path/to/secret.txt
$ export EENGINE_SECRET_FILE=/path/to/secret.txt
$ emailengine
```