### PR TITLE
Added internalDate option for message upload API endpoint

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -2083,6 +2083,11 @@ class Connection {
         data.disableFileAccess = true;
         data.newline = '\r\n';
 
+        if (data.internalDate && !data.date) {
+            // update Date: header as well
+            data.date = new Date(data.internalDate);
+        }
+
         const mail = new MailComposer(data);
         let raw = await mail.compile().build();
 
@@ -2092,7 +2097,7 @@ class Connection {
             let response = {};
 
             try {
-                let uploadResponse = await this.imapClient.append(data.path, raw, data.flags);
+                let uploadResponse = await this.imapClient.append(data.path, raw, data.flags, data.internalDate);
 
                 response.path = uploadResponse.path;
 

--- a/lib/db.js
+++ b/lib/db.js
@@ -30,7 +30,7 @@ const readEnvValue = key => {
     if (typeof process.env[`${key}_FILE`] === 'string' && process.env[`${key}_FILE`]) {
         try {
             // try to load from file
-            process.env[key] = fs.readFileSync(process.env[`${key}_FILE`], 'utf-8');
+            process.env[key] = fs.readFileSync(process.env[`${key}_FILE`], 'utf-8').replace(/\r?\n$/, '');
             logger.trace({ msg: 'Loaded environment value from file', key, file: process.env[`${key}_FILE`] });
         } catch (err) {
             logger.error({ msg: 'Failed to load environment value from file', key, file: process.env[`${key}_FILE`], err });

--- a/lib/get-secret.js
+++ b/lib/get-secret.js
@@ -21,7 +21,7 @@ const readEnvValue = key => {
     if (typeof process.env[`${key}_FILE`] === 'string' && process.env[`${key}_FILE`]) {
         try {
             // try to load from file
-            process.env[key] = fs.readFileSync(process.env[`${key}_FILE`], 'utf-8');
+            process.env[key] = fs.readFileSync(process.env[`${key}_FILE`], 'utf-8').replace(/\r?\n$/, '');
             logger.trace({ msg: 'Loaded environment value from file', key, file: process.env[`${key}_FILE`] });
         } catch (err) {
             logger.error({ msg: 'Failed to load environment value from file', key, file: process.env[`${key}_FILE`], err });

--- a/lib/mailbox.js
+++ b/lib/mailbox.js
@@ -732,6 +732,12 @@ class Mailbox {
         if (messageData.flags && messageData.flags.has('\\Draft')) {
             isDraft = true;
         }
+
+        // do not expose the \Recent flag as it is session specific
+        if (messageData.flags && messageData.flags.has('\\Recent')) {
+            messageData.flags.delete('\\Recent');
+        }
+
         if (messageData.labels && messageData.labels.has('\\Draft')) {
             isDraft = true;
         }

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -1218,7 +1218,7 @@ MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEV3QUiYsp13nD9suD1/ZkEXnuMoSg
         if (typeof process.env[`${key}_FILE`] === 'string' && process.env[`${key}_FILE`]) {
             try {
                 // try to load from file
-                process.env[key] = Fs.readFileSync(process.env[`${key}_FILE`], 'utf-8');
+                process.env[key] = Fs.readFileSync(process.env[`${key}_FILE`], 'utf-8').replace(/\r?\n$/, '');
                 logger.trace({ msg: 'Loaded environment value from file', key, file: process.env[`${key}_FILE`] });
             } catch (err) {
                 logger.error({ msg: 'Failed to load environment value from file', key, file: process.env[`${key}_FILE`], err });

--- a/workers/api.js
+++ b/workers/api.js
@@ -2506,6 +2506,7 @@ When making API calls remember that requests against the same account are queued
                     path: Joi.string().required().example('INBOX').description('Target mailbox folder path'),
 
                     flags: Joi.array().items(Joi.string().max(128)).example(['\\Seen', '\\Draft']).default([]).description('Message flags').label('Flags'),
+                    internalDate: Joi.date().iso().example('2021-07-08T07:06:34.336Z').description('Sets the internal date for this message'),
 
                     reference: Joi.object({
                         message: Joi.string()


### PR DESCRIPTION
Added `internalDate` option for message upload API endpoint

```
curl -XPOST "http://127.0.0.1:3000/v1/account/example/message" \
    -H "Content-type: application/json" \
    -d '{
      "path": "INBOX",
      "flags": ["\\Seen"],
      "internalDate": "2022-06-17T12:00:00.000Z",
...
```