### PR TITLE
Allow to use access tokens as SMTP passwords

### DIFF
--- a/bin/emailengine.js
+++ b/bin/emailengine.js
@@ -182,7 +182,7 @@ function run() {
                 switch (tokensCmd) {
                     case 'issue':
                         {
-                            let allowedScopes = ['*', 'api', 'metrics'];
+                            let allowedScopes = ['*', 'api', 'metrics', 'smtp'];
                             let scopes = []
                                 .concat(argv.scope || [])
                                 .concat(argv.s || [])

--- a/lib/routes-ui.js
+++ b/lib/routes-ui.js
@@ -76,7 +76,7 @@ for (let type of notificationTypes) {
 
 const configSmtpSchema = {
     smtpServerEnabled: settingsSchema.smtpServerEnabled.default(false),
-    smtpServerPassword: settingsSchema.smtpServerPassword.required(),
+    smtpServerPassword: settingsSchema.smtpServerPassword.default(null),
     smtpServerAuthEnabled: settingsSchema.smtpServerAuthEnabled.default(false),
     smtpServerPort: settingsSchema.smtpServerPort,
     smtpServerHost: settingsSchema.smtpServerHost.default('0.0.0.0'),
@@ -2320,7 +2320,7 @@ function applyRoutes(server, call) {
 
                 payload: Joi.object({
                     description: Joi.string().empty('').trim().max(1024).required().example('Token description').description('Token description'),
-                    scopes: Joi.array().items(Joi.string().valid('*', 'api', 'metrics')).required().label('Scopes')
+                    scopes: Joi.array().items(Joi.string().valid('*', 'api', 'metrics', 'smtp')).required().label('Scopes')
                 })
             }
         }

--- a/lib/schemas.js
+++ b/lib/schemas.js
@@ -155,7 +155,7 @@ const settingsSchema = {
         .description('SMTP Host to bind to'),
     smtpServerProxy: Joi.boolean().truthy('Y', 'true', '1', 'on').falsy('N', 'false', 0, '').description('Enable PROXY Protocol for SMTP server'),
     smtpServerAuthEnabled: Joi.boolean().truthy('Y', 'true', '1', 'on').falsy('N', 'false', 0, '').description('Enable SMTP authentication'),
-    smtpServerPassword: Joi.string().empty('').max(1024).description('SMTP client password'),
+    smtpServerPassword: Joi.string().empty('').allow(null).max(1024).description('SMTP client password. Set to null to disable.'),
 
     queueKeep: Joi.number().empty('').min(0).description('How many completed or failed queue entries to keep'),
 

--- a/server.js
+++ b/server.js
@@ -1357,7 +1357,7 @@ const startApplication = async () => {
 
     let existingSecret = await settings.get('smtpServerPassword');
     if (existingSecret === null) {
-        await settings.set('smtpServerPassword', SMTP_SECRET || crypto.randomBytes(16).toString('hex'));
+        await settings.set('smtpServerPassword', SMTP_SECRET || null);
     }
 
     let existingSmtpAuthEnabled = await settings.get('smtpServerAuthEnabled');

--- a/views/config/smtp.hbs
+++ b/views/config/smtp.hbs
@@ -113,6 +113,11 @@
                 {{/if}}
             </div>
 
+            <div class="alert alert-secondary mb-3">
+                Use the account ID as the SMTP username. For SMTP passwords, either set the shared SMTP password below
+                or use <a href="/admin/tokens">access tokens</a> with the <em>SMTP</em> scope.
+            </div>
+
             <div class="form-group">
                 <div class="text-muted float-right code-link">[<a href="/admin/iframe/docs#/settings/postV1Settings"
                         target="_blank">smtpServerPassword</a>]
@@ -123,6 +128,7 @@
                     <input type="password"
                         class="form-control trigger-example-render {{#if errors.smtpServerPassword}}is-invalid{{/if}}"
                         id="smtpServerPassword" name="smtpServerPassword" value="{{values.smtpServerPassword}}"
+                        {{#unless values.smtpServerPassword}}placeholder="Shared SMTP password is not set" {{/unless}}
                         data-lpignore="true" autocomplete="off" />
 
                     <div class="input-group-append">
@@ -134,8 +140,8 @@
                 {{#if errors.smtpServerPassword}}
                 <span class="invalid-feedback">{{errors.smtpServerPassword}}</span>
                 {{/if}}
-                <small class="form-text text-muted">All SMTP accounts share the same password. Username is the account
-                    Id.</small>
+                <small class="form-text text-muted">Shared password for all accounts. Leave this value empty to disable
+                    global shared password.</small>
             </div>
         </div>
 

--- a/views/tokens/new.hbs
+++ b/views/tokens/new.hbs
@@ -50,6 +50,14 @@
 
                 <li class="list-group-item">
                     <div class="form-check">
+                        <input type="checkbox" class="form-check-input scope-entry scope-list" id="scopesSMTP"
+                            name="scopesSMTP" data-scope="smtp" {{#if values.scopesSMTP}}checked{{/if}} />
+                        <label class="form-check-label" for="scopesSMTP">SMTP</label>
+                    </div>
+                </li>
+
+                <li class="list-group-item">
+                    <div class="form-check">
                         <input type="checkbox" class="form-check-input scope-entry scope-list" id="scopesMetrics"
                             name="scopesMetrics" data-scope="metrics" {{#if values.scopesMetrics}}checked{{/if}} />
                         <label class="form-check-label" for="scopesMetrics">Metrics</label>

--- a/workers/api.js
+++ b/workers/api.js
@@ -469,7 +469,7 @@ When making API calls remember that requests against the same account are queued
             if (tokenData.restrictions) {
                 if (tokenData.restrictions.addresses && !tokenData.restrictions.addresses.includes(request.app.ip)) {
                     logger.error({
-                        msg: 'Trying to use invalid account for a token',
+                        msg: 'Trying to use invalid IP for a token',
                         tokenAccount: tokenData.account,
                         tokenId: tokenData.id,
                         account: (request.params && request.params.account) || null,
@@ -1137,6 +1137,8 @@ When making API calls remember that requests against the same account are queued
 
                     description: Joi.string().empty('').trim().max(1024).required().example('Token description').description('Token description'),
 
+                    scopes: Joi.array().items(Joi.string().valid('api', 'smtp')).default(['api']).required().label('Scopes'),
+
                     metadata: Joi.string()
                         .empty('')
                         .max(1024 * 1024)
@@ -1162,7 +1164,7 @@ When making API calls remember that requests against the same account are queued
                                 .default(false)
                                 .example(['*web.domain.org/*', '*.domain.org/*', 'https://domain.org/*'])
                                 .label('ReferrerAllowlist')
-                                .description('HTTP referrer allowlist'),
+                                .description('HTTP referrer allowlist for API requests'),
                             addresses: Joi.array()
                                 .items(
                                     Joi.string().ip({


### PR DESCRIPTION
* Allow settings `null` as the shared SMTP password to disable it
* Added additional access token scope "smtp"
* Allow using "smtp" scoped access tokens as SMTP passwords