### PR TITLE
Alow to set attachment chunk size with ENV value

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ on:
     push:
         branches:
             - master
-            - feature-env-file
+            - feature-chunk-size
 
 name: Deploy test instance
 

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -36,7 +36,8 @@ const {
     MESSAGE_NEW_NOTIFY,
     MESSAGE_DELETED_NOTIFY,
     MESSAGE_UPDATED_NOTIFY,
-    EMAIL_BOUNCE_NOTIFY
+    EMAIL_BOUNCE_NOTIFY,
+    DOWNLOAD_CHUNK_SIZE
 } = require('./consts');
 
 const settings = require('./settings');
@@ -1176,6 +1177,8 @@ class Connection {
      * @returns {Boolean|Stream} Attahcment stream or `false` if not found
      */
     async getAttachment(attachmentId, options) {
+        options = Object.assign({ chunkSize: DOWNLOAD_CHUNK_SIZE }, options || {});
+
         this.checkIMAPConnection();
 
         let buf = Buffer.from(attachmentId, 'base64url');

--- a/lib/consts.js
+++ b/lib/consts.js
@@ -65,6 +65,8 @@ module.exports = {
 
     DEFAULT_PAGE_SIZE: 20,
 
+    DOWNLOAD_CHUNK_SIZE: Math.max(Number(process.env.EENGINE_CHUNK_SIZE) || 0, 0),
+
     REDIS_PREFIX: ((process.env.EENGINE_REDIS_PREFIX || '').toString().trim() + ':').replace(/^:/, ''),
 
     REDIS_BATCH_DELETE_SIZE: 1000,


### PR DESCRIPTION
When downloading attachments, EmailEngine uses chunking instead of downloading the entire attachment in a single call. If the latency between the EmailEngine instance and IMAP server is high, then this chunking approach adds considerable overhead to the download speed, as each chunk requires an additional IMAP command to be sent.

This PR adds the option to increase the default chunk size and thus increase the download speed.

```
EENGINE_CHUNK_SIZE=65536
```