### PR TITLE
Use murmurhash instead of md5 for distribution hashes

### DIFF
--- a/lib/tools.js
+++ b/lib/tools.js
@@ -11,7 +11,7 @@ const settings = require('./settings');
 const { brotliDecompress } = require('zlib');
 const util = require('util');
 const brotliDecompressAsync = util.promisify(brotliDecompress);
-const { createPublicKey, createVerify, createHash, randomBytes, createHmac } = require('crypto');
+const { createPublicKey, createVerify, randomBytes, createHmac } = require('crypto');
 const logger = require('./logger');
 const Boom = require('@hapi/boom');
 const { ImapFlow } = require('imapflow');
@@ -23,6 +23,7 @@ const os = require('os');
 const Fs = require('fs');
 const fs = Fs.promises;
 const pathlib = require('path');
+const { v3: murmurhash } = require('murmurhash');
 const { compare: compareVersions, validate: validateVersion } = require('compare-versions');
 const { REDIS_PREFIX } = require('./consts');
 
@@ -518,13 +519,7 @@ module.exports = {
     },
 
     getRendezvousScore(key, shardId) {
-        const alg = 'md5';
-        return createHash(alg)
-            .update((shardId || '').toString())
-            .update('\x00')
-            .update(key)
-            .digest()
-            .readUInt32LE(0, true);
+        return murmurhash(`${(shardId || '').toString()}\x00${key}`);
     },
 
     selectRendezvousNode(key, workers) {

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
         "mailsplit": "5.3.2",
         "minimist": "1.2.6",
         "msgpack5": "6.0.1",
+        "murmurhash": "2.0.1",
         "nanoid": "3.3.4",
         "node-fetch": "2.6.7",
         "node-html-parser": "5.3.3",


### PR DESCRIPTION
* replace md5 with murmurhash

murmurhash is about 4 times faster than md5 for the use case that EmailEngine uses it (calculating rendezvous scores)