### PR TITLE
Do not reject authentication when 'next' is an empty string

### DIFF
--- a/lib/routes-ui.js
+++ b/lib/routes-ui.js
@@ -3277,7 +3277,7 @@ ${Buffer.from(data.content, 'base64url').toString('base64')}
                 },
 
                 query: Joi.object({
-                    next: Joi.string().uri({ relativeOnly: true }).label('NextUrl')
+                    next: Joi.string().empty('').uri({ relativeOnly: true }).label('NextUrl')
                 })
             }
         }
@@ -3384,7 +3384,7 @@ ${Buffer.from(data.content, 'base64url').toString('base64')}
                     username: Joi.string().max(256).example('user').label('Username').description('Your account username'),
                     password: Joi.string().max(256).min(8).required().example('secret').label('Password').description('Your account password'),
                     remember: Joi.boolean().truthy('Y', 'true', '1', 'on').falsy('N', 'false', 0, '').default(false).description('Remember me'),
-                    next: Joi.string().uri({ relativeOnly: true }).label('NextUrl')
+                    next: Joi.string().empty('').uri({ relativeOnly: true }).label('NextUrl')
                 })
             },
 


### PR DESCRIPTION
When navigating to `/admin/login` without the `next` query argument, then login always failed as the authentication validator detected an empty string value for `next`. This PR fixes this by removing empty `next` values from the schema validation