### PR TITLE
Fix IP restriction handling for IMAP proxy

### DIFF
--- a/lib/imapproxy/imap-server.js
+++ b/lib/imapproxy/imap-server.js
@@ -8,7 +8,7 @@ const os = require('os');
 const punycode = require('punycode/');
 const net = require('net');
 
-const { getDuration, resolveCredentials, readEnvValue, selectRendezvousAddress, emitChangeEvent } = require('../tools');
+const { getDuration, resolveCredentials, readEnvValue, selectRendezvousAddress, emitChangeEvent, matchIp } = require('../tools');
 
 const { redis } = require('../db');
 const { Account } = require('../account');
@@ -249,7 +249,7 @@ async function onAuth(auth, session) {
                     throw err;
                 }
 
-                if (tokenData.restrictions && tokenData.restrictions.addresses && !tokenData.restrictions.addresses.includes(session.remoteAddress)) {
+                if (tokenData.restrictions && tokenData.restrictions.addresses && !matchIp(session.remoteAddress, tokenData.restrictions.addresses)) {
                     logger.error({
                         msg: 'Trying to use invalid IP for a token',
                         tokenAccount: tokenData.account,
@@ -520,7 +520,7 @@ const createServer = function (options = {}) {
                     .catch(err => {
                         if (err.authenticationFailed || err.serverResponseCode === 'AUTHENTICATIONFAILED') {
                             let error = new Error(
-                                `${err.serverResponseCode ? `[${err.serverResponseCode}] ` : ''}${err.responseText || 'Authentication failed'}`
+                                `${err.serverResponseCode ? `[${err.serverResponseCode}] ` : ''}${err.responseText || err.message || 'Authentication failed'}`
                             );
                             error.response = err.responseStatus || 'NO';
                             return callback(error);
@@ -532,6 +532,13 @@ const createServer = function (options = {}) {
             })
             .catch(err => {
                 serverLogger.error({ msg: 'Authentication check failed', username: login.username, err });
+                if (err.authenticationFailed || err.serverResponseCode === 'AUTHENTICATIONFAILED') {
+                    let error = new Error(
+                        `${err.serverResponseCode ? `[${err.serverResponseCode}] ` : ''}${err.responseText || err.message || 'Authentication failed'}`
+                    );
+                    error.response = err.responseStatus || 'NO';
+                    return callback(error);
+                }
                 return callback(err);
             });
     };

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -28,6 +28,7 @@ const mimeTypes = require('nodemailer/lib/mime-funcs/mime-types');
 const { v3: murmurhash } = require('murmurhash');
 const { compare: compareVersions, validate: validateVersion } = require('compare-versions');
 const { REDIS_PREFIX } = require('./consts');
+const ipaddr = require('ipaddr.js');
 
 const nodeFetch = require('node-fetch');
 const fetchCmd = global.fetch || nodeFetch;
@@ -1310,5 +1311,26 @@ MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEV3QUiYsp13nD9suD1/ZkEXnuMoSg
                 data.html = html;
             }
         }
+    },
+
+    matchIp(ip, addresses) {
+        let parsed = ipaddr.parse(ip);
+        for (let addr of addresses) {
+            try {
+                let match;
+                if (/\/\d+$/.test(addr)) {
+                    match = parsed.match(ipaddr.parseCIDR(addr));
+                } else {
+                    match = parsed.toNormalizedString() === ipaddr.parse(addr).toNormalizedString();
+                }
+                if (match) {
+                    return true;
+                }
+            } catch (err) {
+                logger.error({ msg: 'Failed to parse IP address', ip, addr, err });
+            }
+        }
+
+        return false;
     }
 };

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
         "iconv-lite": "0.6.3",
         "imapflow": "1.0.106",
         "ioredis": "5.2.2",
+        "ipaddr.js": "2.0.1",
         "joi": "17.6.0",
         "joi18n": "2.0.3",
         "jquery": "3.6.0",

--- a/translations/messages.pot
+++ b/translations/messages.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Content-Type: text/plain; charset=ascii\n"
-"POT-Creation-Date: 2022-08-23 13:54+0000\n"
+"POT-Creation-Date: 2022-08-23 14:03+0000\n"
 
 #: views/config/license.hbs:48
 msgid "%d day"

--- a/workers/api.js
+++ b/workers/api.js
@@ -21,7 +21,8 @@ const {
     getWorkerCount,
     assertPreconditions,
     matcher,
-    readEnvValue
+    readEnvValue,
+    matchIp
 } = require('../lib/tools');
 
 const Bugsnag = require('@bugsnag/js');
@@ -609,7 +610,7 @@ When making API calls remember that requests against the same account are queued
             }
 
             if (tokenData.restrictions) {
-                if (tokenData.restrictions.addresses && !tokenData.restrictions.addresses.includes(request.app.ip)) {
+                if (tokenData.restrictions.addresses && !matchIp(request.app.ip, tokenData.restrictions.addresses)) {
                     logger.error({
                         msg: 'Trying to use invalid IP for a token',
                         tokenAccount: tokenData.account,
@@ -1279,7 +1280,7 @@ When making API calls remember that requests against the same account are queued
 
                     description: Joi.string().empty('').trim().max(1024).required().example('Token description').description('Token description'),
 
-                    scopes: Joi.array().items(Joi.string().valid('api', 'smtp')).default(['api']).required().label('Scopes'),
+                    scopes: Joi.array().items(Joi.string().valid('api', 'smtp', 'imap-proxy')).single().default(['api']).required().label('Scopes'),
 
                     metadata: Joi.string()
                         .empty('')
@@ -1301,6 +1302,7 @@ When making API calls remember that requests against the same account are queued
                         referrers: Joi.array()
                             .items(Joi.string())
                             .empty('')
+                            .single()
                             .allow(false)
                             .default(false)
                             .example(['*web.domain.org/*', '*.domain.org/*', 'https://domain.org/*'])
@@ -1310,13 +1312,14 @@ When making API calls remember that requests against the same account are queued
                             .items(
                                 Joi.string().ip({
                                     version: ['ipv4', 'ipv6'],
-                                    cidr: 'forbidden'
+                                    cidr: 'optional'
                                 })
                             )
                             .empty('')
+                            .single()
                             .allow(false)
                             .default(false)
-                            .example(['1.2.3.4', '5.6.7.8'])
+                            .example(['1.2.3.4', '5.6.7.8', '127.0.0.0/8'])
                             .label('AddressAllowlist')
                             .description('IP address allowlist')
                     })
@@ -1557,13 +1560,13 @@ When making API calls remember that requests against the same account are queued
                                         .items(
                                             Joi.string().ip({
                                                 version: ['ipv4', 'ipv6'],
-                                                cidr: 'forbidden'
+                                                cidr: 'optional'
                                             })
                                         )
                                         .empty('')
                                         .allow(false)
                                         .default(false)
-                                        .example(['1.2.3.4', '5.6.7.8'])
+                                        .example(['1.2.3.4', '5.6.7.8', '127.0.0.0/8'])
                                         .label('AddressAllowlist')
                                         .description('IP address allowlist')
                                 })

--- a/workers/smtp.js
+++ b/workers/smtp.js
@@ -6,7 +6,7 @@ const packageData = require('../package.json');
 const config = require('wild-config');
 const logger = require('../lib/logger');
 
-const { getDuration, emitChangeEvent, readEnvValue } = require('../lib/tools');
+const { getDuration, emitChangeEvent, readEnvValue, matchIp } = require('../lib/tools');
 
 const Bugsnag = require('@bugsnag/js');
 if (readEnvValue('BUGSNAG_API_KEY')) {
@@ -156,7 +156,7 @@ async function onAuth(auth, session) {
                     throw new Error('Access denied, invalid scope');
                 }
 
-                if (tokenData.restrictions && tokenData.restrictions.addresses && !tokenData.restrictions.addresses.includes(session.remoteAddress)) {
+                if (tokenData.restrictions && tokenData.restrictions.addresses && !matchIp(session.remoteAddress, tokenData.restrictions.addresses)) {
                     logger.error({
                         msg: 'Trying to use invalid IP for a token',
                         tokenAccount: tokenData.account,


### PR DESCRIPTION
* Allow creating user tokens with `imap-proxy` scope
* Allow using CIDR ranges for IP restrictions
* Show correct authfail error for IMAP proxy failing authentication requests