### PR TITLE
Fix CLI trailing newlines

### DIFF
--- a/bin/emailengine.js
+++ b/bin/emailengine.js
@@ -71,7 +71,6 @@ function run() {
                     .then(res => {
                         let returnValue = argv.hash || argv.r ? Buffer.from(res.passwordHash).toString('base64url') : res.password;
                         process.stdout.write(returnValue);
-                        console.error('');
                         return process.exit(0);
                     })
                     .catch(err => {
@@ -91,7 +90,6 @@ function run() {
                     return process.exit(1);
                 }
                 console.error(helpText.toString().trim());
-                console.error('');
                 process.exit();
             });
             break;
@@ -109,7 +107,6 @@ function run() {
                         .exportLicense()
                         .then(license => {
                             process.stdout.write(license);
-                            console.error('');
                             return process.exit(0);
                         })
                         .catch(err => {
@@ -205,7 +202,6 @@ function run() {
                                 })
                                 .then(token => {
                                     process.stdout.write(token);
-                                    console.error('');
                                     process.exit();
                                 })
                                 .catch(err => {
@@ -223,7 +219,6 @@ function run() {
                                 .then(tokenData => {
                                     let encoded = msgpack.encode(tokenData);
                                     process.stdout.write(encoded.toString('base64url'));
-                                    console.error('');
                                     process.exit();
                                 })
                                 .catch(err => {

--- a/bin/emailengine.js
+++ b/bin/emailengine.js
@@ -70,7 +70,8 @@ function run() {
                 updatePassword()
                     .then(res => {
                         let returnValue = argv.hash || argv.r ? Buffer.from(res.passwordHash).toString('base64url') : res.password;
-                        console.log(returnValue);
+                        process.stdout.write(returnValue);
+                        console.error('');
                         return process.exit(0);
                     })
                     .catch(err => {
@@ -107,7 +108,8 @@ function run() {
                     return settings
                         .exportLicense()
                         .then(license => {
-                            console.log(license);
+                            process.stdout.write(license);
+                            console.error('');
                             return process.exit(0);
                         })
                         .catch(err => {
@@ -145,8 +147,10 @@ function run() {
                     console.error('EmailEngine License');
                     console.error('===================');
 
-                    console.log(`EmailEngine v${packageData.version}`);
-                    console.error(`(c) 2020-${new Date().getFullYear()} Postal Systems`);
+                    // if only stdout is read, only this line is is seen:
+                    process.stdout.write(`EmailEngine v${packageData.version}`);
+
+                    console.error(`\n(c) 2020-${new Date().getFullYear()} Postal Systems`);
                     console.error(`${packageData.license}, full text follows`);
                     console.error('');
 
@@ -182,7 +186,7 @@ function run() {
                             for (let scope of scopes) {
                                 if (!allowedScopes.includes(scope)) {
                                     console.error(`Unknown scope: ${scope}`);
-                                    console.log(`Allowed scopes: "${allowedScopes.join('", "')}"`);
+                                    console.error(`Allowed scopes: "${allowedScopes.join('", "')}"`);
                                     process.exit(1);
                                 }
                             }
@@ -200,7 +204,8 @@ function run() {
                                     nolog: true
                                 })
                                 .then(token => {
-                                    console.log(token);
+                                    process.stdout.write(token);
+                                    console.error('');
                                     process.exit();
                                 })
                                 .catch(err => {
@@ -217,7 +222,8 @@ function run() {
                                 .getRawData(token)
                                 .then(tokenData => {
                                     let encoded = msgpack.encode(tokenData);
-                                    console.log(encoded.toString('base64url'));
+                                    process.stdout.write(encoded.toString('base64url'));
+                                    console.error('');
                                     process.exit();
                                 })
                                 .catch(err => {


### PR DESCRIPTION
EmailEngine CLI commands for issuing tokens, exporting licenses, etc included a trailing newline that, in some cases, when using that output in scripts, caused issues with unexpected newlines.