### PR TITLE
Process DocumentStore entry before sending a webhook

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -108,6 +108,7 @@ class Connection {
         this.notifyQueue = options.notifyQueue;
         this.submitQueue = options.submitQueue;
         this.documentsQueue = options.documentsQueue;
+        this.flowProducer = options.flowProducer;
 
         this.refreshListingTimer = false;
         this.resyncTimer = false;
@@ -640,32 +641,57 @@ class Connection {
 
         let queueKeep = (await settings.get('queueKeep')) || true;
 
-        if (!skipWebhook) {
-            await this.notifyQueue.add(event, payload, {
-                removeOnComplete: queueKeep,
-                removeOnFail: queueKeep,
-                attempts: 10,
-                backoff: {
-                    type: 'exponential',
-                    delay: 5000
-                }
-            });
-        }
-
-        if (
+        let addDocumentQueueJob =
             this.documentsQueue &&
             [MESSAGE_NEW_NOTIFY, MESSAGE_DELETED_NOTIFY, MESSAGE_UPDATED_NOTIFY, EMAIL_BOUNCE_NOTIFY].includes(event) &&
-            (await settings.get('documentStoreEnabled'))
-        ) {
-            await this.documentsQueue.add(event, payload, {
-                removeOnComplete: queueKeep,
-                removeOnFail: queueKeep,
-                attempts: 10,
-                backoff: {
-                    type: 'exponential',
-                    delay: 5000
+            (await settings.get('documentStoreEnabled'));
+
+        const jobOptions = {
+            removeOnComplete: queueKeep,
+            removeOnFail: queueKeep,
+            attempts: 10,
+            backoff: {
+                type: 'exponential',
+                delay: 5000
+            }
+        };
+
+        if (!skipWebhook && addDocumentQueueJob) {
+            // add both jobs as a Flow
+            await this.flowProducer.add(
+                {
+                    name: event,
+                    data: payload,
+                    queueName: 'notify',
+                    children: [
+                        {
+                            name: event,
+                            data: payload,
+                            queueName: 'documents'
+                        }
+                    ]
+                },
+                {
+                    queuesOptions: {
+                        notify: {
+                            defaultJobOptions: jobOptions
+                        },
+                        documents: {
+                            defaultJobOptions: jobOptions
+                        }
+                    }
                 }
-            });
+            );
+        } else {
+            // add to queues as normal jobs
+
+            if (!skipWebhook) {
+                await this.notifyQueue.add(event, payload, jobOptions);
+            }
+
+            if (addDocumentQueueJob) {
+                await this.documentsQueue.add(event, payload, jobOptions);
+            }
         }
     }
 

--- a/lib/db.js
+++ b/lib/db.js
@@ -18,7 +18,7 @@ config.dbs = config.dbs || {
     redis: 'redis://127.0.0.1:6379/8'
 };
 
-const { Queue } = require('bullmq');
+const { Queue, FlowProducer } = require('bullmq');
 const Redis = require('ioredis');
 
 // duplicat function declaration to avoid requireing tools.js
@@ -65,7 +65,6 @@ module.exports.queueConf = {
 
 const notifyQueue = new Queue('notify', module.exports.queueConf);
 const submitQueue = new Queue('submit', module.exports.queueConf);
-
 const documentsQueue = new Queue('documents', module.exports.queueConf);
 
 const zExpungeScript = fs.readFileSync(pathlib.join(__dirname, '/lua/z-expunge.lua'), 'utf-8');
@@ -139,6 +138,10 @@ module.exports.redis = redis;
 module.exports.notifyQueue = notifyQueue;
 module.exports.submitQueue = submitQueue;
 module.exports.documentsQueue = documentsQueue;
+
+// do not set up the flow producer by default
+module.exports.getFlowProducer = () => new FlowProducer(module.exports.queueConf /*, Redis*/);
+
 module.exports.REDIS_CONF = REDIS_CONF;
 
 redis.on('error', err => {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "homepage": "https://emailengine.app/",
     "dependencies": {
         "@bugsnag/js": "7.17.0",
-        "@elastic/elasticsearch": "8.2.1",
+        "@elastic/elasticsearch": "8.4.0",
         "@hapi/boom": "10.0.0",
         "@hapi/cookie": "11.0.2",
         "@hapi/crumb": "8.0.1",

--- a/workers/imap.js
+++ b/workers/imap.js
@@ -33,13 +33,15 @@ if (readEnvValue('BUGSNAG_API_KEY')) {
 
 const { Connection } = require('../lib/connection');
 const { Account } = require('../lib/account');
-const { redis, notifyQueue, submitQueue, documentsQueue } = require('../lib/db');
+const { redis, notifyQueue, submitQueue, documentsQueue, getFlowProducer } = require('../lib/db');
 const { MessagePortWritable } = require('../lib/message-port-stream');
 const { getESClient } = require('../lib/document-store');
 const settings = require('../lib/settings');
 const msgpack = require('msgpack5')();
 
 const getSecret = require('../lib/get-secret');
+
+const flowProducer = getFlowProducer();
 
 config.service = config.service || {};
 
@@ -133,6 +135,7 @@ class ConnectionHandler {
             notifyQueue,
             submitQueue,
             documentsQueue,
+            flowProducer,
             accountLogger,
             logRaw: EENGINE_LOG_RAW
         });


### PR DESCRIPTION
Make sure an email is stored in ElasticSearch first before sending out a webhook