### PR TITLE
Allow setting mail merge specific send at values

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -1965,10 +1965,17 @@ class Connection {
         for (let mailMergeEntry of mailMergeList) {
             // poor man's structuredClone() (EmailEngine needs to support Node versions 16+)
             let messageCopy = JSON.parse(JSON.stringify(data));
+            if (messageCopy.sendAt) {
+                // date values do not survive JSON based copying
+                messageCopy.sendAt = new Date(messageCopy.sendAt);
+            }
+
             messageCopy.to = [mailMergeEntry.to];
 
-            if (mailMergeEntry.messageId) {
-                messageCopy.messageId = mailMergeEntry.messageId;
+            for (let key of ['messageId', 'sendAt']) {
+                if (mailMergeEntry[key]) {
+                    messageCopy[key] = mailMergeEntry[key];
+                }
             }
 
             if (mailMergeEntry.params) {
@@ -1979,8 +1986,6 @@ class Connection {
             messageProcessors.push(this.queueMessageEntry(messageCopy, meta));
         }
 
-        let sendAt;
-
         let response = {
             mailMerge: []
         };
@@ -1990,10 +1995,6 @@ class Connection {
             let mailMergeEntry = mailMergeList[i];
             let resultEntry = results[i];
 
-            if (!sendAt && resultEntry.value && resultEntry.value.sendAt) {
-                sendAt = resultEntry.value.sendAt;
-            }
-
             let result = Object.assign(
                 {
                     success: resultEntry.status === 'fulfilled',
@@ -2002,7 +2003,8 @@ class Connection {
                 resultEntry.status === 'fulfilled'
                     ? {
                           messageId: resultEntry.value.messageId,
-                          queueId: resultEntry.value.queueId
+                          queueId: resultEntry.value.queueId,
+                          sendAt: resultEntry.value.sendAt
                       }
                     : {
                           error: (resultEntry.reason && resultEntry.reason.message) || resultEntry.status,
@@ -2012,10 +2014,6 @@ class Connection {
             );
 
             response.mailMerge.push(result);
-        }
-
-        if (sendAt) {
-            response.sendAt = sendAt;
         }
 
         return response;
@@ -2300,6 +2298,7 @@ class Connection {
 
         // Use timestamp in the ID to make sure that jobs are ordered by send time
         let timeBuf = Buffer.allocUnsafe(8);
+
         timeBuf.writeBigInt64BE(BigInt((sendAt && sendAt.getTime()) || Date.now()), 0);
 
         let queueId = Buffer.concat([timeBuf.slice(2), crypto.randomBytes(4)])

--- a/views/dashboard.hbs
+++ b/views/dashboard.hbs
@@ -233,17 +233,6 @@
                 console.error(err);
             }
 
-            try {
-                // load swagger file to trigger caching
-                const res = await fetch('/swagger.json', {
-                    method: 'get'
-                });
-                if (!res.ok) {
-                    console.error('Failed to fetch swagger definition');
-                }
-            } catch (err) {
-                console.error(err);
-            }
         }
 
         sendBrowserInfo().catch(err => console.error(err))


### PR DESCRIPTION
* `mailMerge` structure accepts new propety `sendAt` that will override the message level `sendAt` value
* Fixed a bug with mail merge and message level `sendAt` processing
* Trigger request against swagger.json on server startup to trigger caching