### PR TITLE
Prefer account email address when setting up OAuth2 accounts

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ on:
     push:
         branches:
             - master
-            - cache-swagger-json
+            - oauth-prefer-account-email
 
 name: Deploy test instance
 

--- a/views/accounts/account.hbs
+++ b/views/accounts/account.hbs
@@ -81,7 +81,7 @@
 
             {{#if oauth2ProviderEnabled}}
             <div class="btn-group mr-2 mb-1" role="group" aria-label="Second group">
-                <button type="button" class="btn btn-light" data-toggle="modal" data-target="#renewGrantdModal"
+                <button type="button" class="btn btn-light" data-toggle="modal" data-target="#renewGrantModal"
                     title="Re-authenticate OAuth2 account" id="renew-grant-btn" data-placement="top">
                     {{#if account.type.icon}}
                     <i class="{{account.type.icon}} fa-fw"></i>

--- a/views/accounts/account.hbs
+++ b/views/accounts/account.hbs
@@ -395,8 +395,11 @@
                 </button>
             </div>
             <div class="modal-body">
-                <p>Are you sure you want to delete the account for {{account.name}}? This action is not
-                    recoverable.</p>
+                <p>
+                    When renewing the OAuth2 grant, ensure you are not logged in to another account for the same
+                    provider in this browser. Otherwise, that account might override the settings and messages for
+                    <em>{{account.name}}</em> in EmailEngine.
+                </p>
             </div>
             <div class="modal-footer">
                 <form method="post" action="/accounts/new">

--- a/views/accounts/account.hbs
+++ b/views/accounts/account.hbs
@@ -68,7 +68,7 @@
                         {{/each}}
                     </div>
                 </div>
-                {{/if}}
+                {{/unless}}
                 {{/if}}
 
                 <a type="button" class="btn btn-light" href="/admin/accounts/{{account.account}}/logs.txt"

--- a/views/accounts/account.hbs
+++ b/views/accounts/account.hbs
@@ -42,6 +42,12 @@
                 </a>
 
                 {{#if canSend}}
+                {{#unless gateways}}
+                <button type="button" class="btn btn-light" data-toggle="modal" data-target="#testSendModal"
+                    title="Test SMTP delivery settings for this account" id="test-smtp-btn" data-placement="top">
+                    <i class="fas fa-envelope-open-text fa-fw" id="test-smtp-icon"></i> Delivery test
+                </button>
+                {{else}}
                 <div class="btn-group">
                     <button type="button" class="btn btn-light dropdown-toggle" data-toggle="dropdown"
                         aria-expanded="false" title="Test SMTP delivery settings for this account" id="test-smtp-btn">
@@ -63,6 +69,7 @@
                     </div>
                 </div>
                 {{/if}}
+                {{/if}}
 
                 <a type="button" class="btn btn-light" href="/admin/accounts/{{account.account}}/logs.txt"
                     title="Download stored logs for &quot;{{account.account}}&quot;" data-toggle="tooltip"
@@ -73,17 +80,12 @@
 
             {{#if oauth2ProviderEnabled}}
             <div class="btn-group mr-2 mb-1" role="group" aria-label="Second group">
-                <form method="post" action="/accounts/new">
-                    <input type="hidden" name="crumb" value="{{crumb}}">
-                    <input type="hidden" name="type" value="{{account.oauth2.provider}}">
-                    <input type="hidden" name="data" value="{{accountForm.data}}">
-                    <input type="hidden" name="sig" value="{{accountForm.signature}}">
-                    <button type="submit" class="btn btn-light">
-                        {{#if account.type.icon}}
-                        <i class="{{account.type.icon}} fa-fw"></i>
-                        {{/if}} Renew grant
-                    </button>
-                </form>
+                <button type="button" class="btn btn-light" data-toggle="modal" data-target="#renewGrantdModal"
+                    title="Re-authenticate OAuth2 account" id="renew-grant-btn" data-placement="top">
+                    {{#if account.type.icon}}
+                    <i class="{{account.type.icon}} fa-fw"></i>
+                    {{/if}} Renew grant
+                </button>
             </div>
             {{/if}}
         </div>
@@ -383,6 +385,37 @@
 </div>
 {{/if}}
 
+<div class="modal fade" id="renewGrantModal" tabindex="-1" aria-labelledby="renewGrantLabel" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="renewGrantLabel">Renew grant</h5>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+            </div>
+            <div class="modal-body">
+                <p>Are you sure you want to delete the account for {{account.name}}? This action is not
+                    recoverable.</p>
+            </div>
+            <div class="modal-footer">
+                <form method="post" action="/accounts/new">
+                    <input type="hidden" name="crumb" value="{{crumb}}">
+                    <input type="hidden" name="type" value="{{account.oauth2.provider}}">
+                    <input type="hidden" name="data" value="{{accountForm.data}}">
+                    <input type="hidden" name="sig" value="{{accountForm.signature}}">
+                    <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
+                    <button type="submit" class="btn btn-primary">
+                        {{#if account.type.icon}}
+                        <i class="{{account.type.icon}} fa-fw"></i>
+                        {{/if}} Renew grant
+                    </button>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+
 <div class="modal fade" id="deleteModal" tabindex="-1" aria-labelledby="deleteModalLabel" aria-hidden="true">
     <div class="modal-dialog">
         <div class="modal-content">
@@ -623,8 +656,12 @@
         // not set up by default as this element has a different data-toggle
         $('#delete-btn').tooltip();
         $('#delete-btn').click(() => $('#delete-btn').tooltip('hide'));
+
         $('#test-smtp-btn').tooltip();
         $('#test-smtp-btn').click(() => $('#test-smtp-btn').tooltip('hide'));
+
+        $('#renew-grant-btn').tooltip();
+        $('#renew-grant-btn').click(() => $('#renew-grant-btn').tooltip('hide'));
     });
 </script>
 

--- a/views/accounts/account.hbs
+++ b/views/accounts/account.hbs
@@ -44,7 +44,8 @@
                 {{#if canSend}}
                 {{#unless gateways}}
                 <button type="button" class="btn btn-light" data-toggle="modal" data-target="#testSendModal"
-                    title="Test SMTP delivery settings for this account" id="test-smtp-btn" data-placement="top">
+                    title="Test SMTP delivery settings for this account" data-account="{{account.account}}"
+                    id="test-smtp-btn" data-placement="top">
                     <i class="fas fa-envelope-open-text fa-fw" id="test-smtp-icon"></i> Delivery test
                 </button>
                 {{else}}

--- a/workers/api.js
+++ b/workers/api.js
@@ -1072,7 +1072,7 @@ When making API calls remember that requests against the same account are queued
                         throw error;
                     }
 
-                    accountData.email = accountData.email || (isEmail(profileRes.emailAddress) ? profileRes.emailAddress : '');
+                    accountData.email = isEmail(profileRes.emailAddress) ? profileRes.emailAddress : accountData.email;
 
                     accountData.oauth2 = Object.assign(
                         accountData.oauth2 || {},
@@ -1140,7 +1140,7 @@ When making API calls remember that requests against the same account are queued
                     }
 
                     accountData.name = accountData.name || userInfo.name || '';
-                    accountData.email = accountData.email || userInfo.email;
+                    accountData.email = userInfo.email;
 
                     accountData.oauth2 = Object.assign(
                         accountData.oauth2 || {},
@@ -1187,7 +1187,7 @@ When making API calls remember that requests against the same account are queued
                     }
 
                     accountData.name = accountData.name || profileRes.name || '';
-                    accountData.email = accountData.email || (isEmail(profileRes.email) ? profileRes.email : '');
+                    accountData.email = isEmail(profileRes.email) ? profileRes.email : accountData.email;
 
                     accountData.oauth2 = Object.assign(
                         accountData.oauth2 || {},

--- a/workers/api.js
+++ b/workers/api.js
@@ -1830,7 +1830,7 @@ When making API calls remember that requests against the same account are queued
 
                 for (let accountType of ['gmail', 'outlook', 'mailRu']) {
                     let typeEnabled = await settings.get(`${accountType}Enabled`);
-                    if (typeEnabled && (!(await settings.get(`${accountType}gmailClientId`)) || !(await settings.get(`${accountType}ClientSecret`)))) {
+                    if (typeEnabled && (!(await settings.get(`${accountType}ClientId`)) || !(await settings.get(`${accountType}ClientSecret`)))) {
                         typeEnabled = false;
                         if (type === accountType) {
                             type = false;


### PR DESCRIPTION
* Oauth2 account email overrides the email address provided as the account address for the authentication form
* Fixed a minor bug with default type for `/v1/authentication/form`
* Show a confirmation when clicking on the "renew grant" button
* Do not show a dropdown for delivery tests when there are not registered SMTP gateways