### PR TITLE
Added new webhook type - messageComplaint

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ on:
     push:
         branches:
             - master
-            - oauth-prefer-account-email
+            - feature-arf-webhook
 
 name: Deploy test instance
 

--- a/lib/arf-detect.js
+++ b/lib/arf-detect.js
@@ -1,0 +1,130 @@
+'use strict';
+
+const libmime = require('libmime');
+const addressparser = require('nodemailer/lib/addressparser');
+
+const ARF_SINGLE = [
+    'feedback-type',
+    'user-agent',
+    'version',
+    'original-envelope-id',
+    'original-mail-from',
+    'abuse-type',
+    'arrival-date',
+    'received-date',
+    'reporting-mta',
+    'source-ip',
+    'source',
+    'subscription-link',
+    'incidents'
+];
+
+const arfDetect = async messageInfo => {
+    const report = {};
+
+    for (let attachment of messageInfo.attachments) {
+        switch (attachment.contentType.toLowerCase()) {
+            case 'message/feedback-report': {
+                // found a feedback report
+
+                const contents = libmime.decodeHeaders((attachment.content || '').toString());
+
+                // eslint-disable-next-line no-loop-func
+                Object.keys(contents).forEach(key => {
+                    let value = contents[key];
+
+                    if (!key || !value) {
+                        return;
+                    }
+
+                    if (ARF_SINGLE.includes(key)) {
+                        value = Array.isArray(contents[key]) ? contents[key].join(',') : (contents[key] || '').toString();
+                    } else if (!Array.isArray(value)) {
+                        value = []
+                            .concat(value || [])
+                            .map(element => (element || '').toString().trim())
+                            .filter(element => element);
+                    }
+
+                    if (!value || !value.length) {
+                        return;
+                    }
+
+                    switch (key) {
+                        case 'original-mail-from':
+                            value = value.replace(/^[\s<]*|[>\s]*$/g, '');
+                            break;
+
+                        case 'arrival-date':
+                        case 'received-date':
+                            key = 'arrival-date';
+                            value = new Date(value);
+                            if (value.toString() === 'Invalid Date') {
+                                return;
+                            }
+                            value = value.toISOString();
+                            break;
+                    }
+
+                    report[key] = value;
+                });
+
+                break;
+            }
+
+            case 'message/rfc822':
+            case 'message/rfc822-headers': {
+                let contents = (attachment.content || '').toString();
+                const headerPos = contents.match(/\r?\n\r?\n/);
+
+                if (headerPos) {
+                    contents = contents.substr(0, headerPos.index);
+                }
+
+                const headers = libmime.decodeHeaders(contents);
+
+                // Hotmail original recipient X-HmXmrOriginalRecipient
+                const addresses = addressparser([].concat(headers['x-hmxmroriginalrecipient'] || []).join(', '))
+                    .map(addr => addr.address)
+                    .filter(addr => addr && !(report['original-rcpt-to'] && report['original-rcpt-to'].includes(addr)));
+
+                report['original-rcpt-to'] = [].concat(report['original-rcpt-to'] || []).concat(addresses);
+
+                let messageId = [].concat(headers['message-id'] || []).pop();
+                if (messageId && !report['message-id']) {
+                    report['message-id'] = messageId;
+                }
+
+                let sourceIp = [].concat(headers['x-sender-ip'] || []).pop();
+                if (sourceIp && !report['source-ip']) {
+                    report['source-ip'] = sourceIp;
+                }
+
+                let originalArrivalTime = [].concat(headers['x-ms-exchange-crosstenant-originalarrivaltime'] || []).pop();
+                if (originalArrivalTime && !report['arrival-date']) {
+                    let originalArrivalTimeDate = new Date(originalArrivalTime);
+                    if (originalArrivalTimeDate && originalArrivalTimeDate.toString() !== 'Invalid Date') {
+                        report['arrival-date'] = originalArrivalTimeDate.toISOString();
+                    }
+                }
+
+                break;
+            }
+
+            default:
+                break;
+        }
+    }
+
+    let reportDefauls = {};
+
+    if (!report.source && messageInfo.from && messageInfo.from.address === 'staff@hotmail.com') {
+        reportDefauls.source = 'Hotmail';
+        reportDefauls.feedbackType = reportDefauls.feedbackType || 'abuse';
+        reportDefauls.abuseType = reportDefauls.abuseType || 'complaint';
+    }
+
+    return Object.assign(reportDefauls, report);
+};
+
+module.exports = { arfDetect };

--- a/lib/consts.js
+++ b/lib/consts.js
@@ -27,6 +27,9 @@ module.exports = {
     EMAIL_BOUNCE_NOTIFY: 'messageBounce',
     EMAIL_BOUNCE_DESCRIPTION: 'Bounce Received – Bounce response email is received (bounce received)',
 
+    EMAIL_COMPLAINT_NOTIFY: 'messageComplaint',
+    EMAIL_COMPLAINT_DESCRIPTION: 'Complaint received – FBL complaint was detected',
+
     MAILBOX_RESET_NOTIFY: 'mailboxReset',
     MAILBOX_RESET_DESCRIPTION: 'Mailbox Reset – UIDValidity for a folder changes (mailbox reset)',
 

--- a/lib/mailbox.js
+++ b/lib/mailbox.js
@@ -7,6 +7,7 @@ const he = require('he');
 const libmime = require('libmime');
 const settings = require('./settings');
 const { bounceDetect } = require('./bounce-detect');
+const { arfDetect } = require('./arf-detect');
 const appendList = require('./append-list');
 
 const { getESClient } = require('./document-store');
@@ -19,6 +20,7 @@ const {
     MAILBOX_RESET_NOTIFY,
     MAILBOX_NEW_NOTIFY,
     EMAIL_BOUNCE_NOTIFY,
+    EMAIL_COMPLAINT_NOTIFY,
     REDIS_PREFIX
 } = require('./consts');
 
@@ -484,6 +486,9 @@ class Mailbox {
                 fetchHeaders.add('auto-submitted');
                 fetchHeaders.add('precedence');
 
+                fetchHeaders.add('in-reply-to');
+                fetchHeaders.add('references');
+
                 messageFetchOptions.fetchHeaders = Array.from(fetchHeaders);
             }
 
@@ -598,6 +603,53 @@ class Mailbox {
         }
 
         let bounceNotifyInfo;
+        let complaintNotifyInfo;
+
+        if (this.mightBeAComplaint(messageInfo)) {
+            try {
+                for (let attachment of messageInfo.attachments) {
+                    if (!['message/feedback-report', 'message/rfc822-headers', 'message/rfc822'].includes(attachment.contentType)) {
+                        continue;
+                    }
+
+                    let buf = Buffer.from(attachment.id, 'base64url');
+                    let part = buf.slice(8).toString();
+
+                    let { content } = await this.connection.imapClient.download(messageInfo.uid, part, {
+                        uid: true,
+                        // headers should fit into 1MB, don't need all contents
+                        maxBytes: 1 * 1024 * 1024,
+                        chunkSize: options.chunkSize
+                    });
+
+                    if (content) {
+                        attachment.content = (await this.download(content)).toString();
+                    }
+                }
+
+                const report = await arfDetect(messageInfo);
+
+                if (report && report['original-rcpt-to'] && report['original-rcpt-to'].length) {
+                    // can send report
+                    let complaint = {};
+                    for (let key of Object.keys(report)) {
+                        complaint[key.replace(/-(.)/g, (o, c) => c.toUpperCase())] = report[key];
+                    }
+
+                    complaintNotifyInfo = Object.assign({ complaintMessage: messageInfo.id }, complaint);
+
+                    messageInfo.isComplaint = true;
+                }
+            } catch (err) {
+                this.logger.error({
+                    msg: 'Failed to process ARF',
+                    id: messageInfo.id,
+                    uid: messageInfo.uid,
+                    messageId: messageInfo.messageId,
+                    err
+                });
+            }
+        }
 
         // Check if this could be a bounce
         if (this.mightBeABounce(messageInfo)) {
@@ -750,6 +802,13 @@ class Mailbox {
 
             // send bounce notification _after_ bounce email notification
             await this.connection.notify(false, EMAIL_BOUNCE_NOTIFY, bounceNotifyInfo, {
+                skipWebhook: this.connection.notifyFrom && date < this.connection.notifyFrom
+            });
+        }
+
+        if (complaintNotifyInfo) {
+            // send complaint notification _after_ complaint email notification
+            await this.connection.notify(false, EMAIL_COMPLAINT_NOTIFY, complaintNotifyInfo, {
                 skipWebhook: this.connection.notifyFrom && date < this.connection.notifyFrom
             });
         }
@@ -1069,6 +1128,9 @@ class Mailbox {
                 fetchHeaders.add('x-autorespond');
                 fetchHeaders.add('auto-submitted');
                 fetchHeaders.add('precedence');
+
+                fetchHeaders.add('in-reply-to');
+                fetchHeaders.add('references');
 
                 messageFetchOptions.fetchHeaders = Array.from(fetchHeaders);
             }
@@ -1841,6 +1903,31 @@ class Mailbox {
         }
 
         if (/mailer-daemon@|postmaster@/i.test(address)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    mightBeAComplaint(messageInfo) {
+        if (this.path !== 'INBOX' && !(this.isAllMail && messageInfo.labels && messageInfo.labels.includes('\\Inbox'))) {
+            return false;
+        }
+
+        let hasEmbeddedMessage = false;
+        for (let attachment of messageInfo.attachments || []) {
+            if (attachment.contentType === 'message/feedback-report') {
+                return true;
+            }
+
+            if (['message/rfc822', 'message/rfc822-headers'].includes(attachment.contentType)) {
+                hasEmbeddedMessage = true;
+            }
+        }
+
+        let fromAddress = (messageInfo.from && messageInfo.from.address) || '';
+
+        if (hasEmbeddedMessage && fromAddress === 'staff@hotmail.com' && /complaint/i.test(messageInfo.subject)) {
             return true;
         }
 


### PR DESCRIPTION
* Whenever a complaint is detected (usually an ARF report), then EmailEngine emits a webhook `messageComplaint`