### PR TITLE
Group webhook data into arf and headers objects

### DIFF
--- a/lib/arf-detect.js
+++ b/lib/arf-detect.js
@@ -20,7 +20,10 @@ const ARF_SINGLE = [
 ];
 
 const arfDetect = async messageInfo => {
-    const report = {};
+    const report = {
+        arf: {},
+        headers: {}
+    };
 
     for (let attachment of messageInfo.attachments) {
         switch (attachment.contentType.toLowerCase()) {
@@ -66,7 +69,7 @@ const arfDetect = async messageInfo => {
                             break;
                     }
 
-                    report[key] = value;
+                    report.arf[key] = value;
                 });
 
                 break;
@@ -86,25 +89,74 @@ const arfDetect = async messageInfo => {
                 // Hotmail original recipient X-HmXmrOriginalRecipient
                 const addresses = addressparser([].concat(headers['x-hmxmroriginalrecipient'] || []).join(', '))
                     .map(addr => addr.address)
-                    .filter(addr => addr && !(report['original-rcpt-to'] && report['original-rcpt-to'].includes(addr)));
+                    .filter(addr => addr && !(report.arf['original-rcpt-to'] && report.arf['original-rcpt-to'].includes(addr)));
 
-                report['original-rcpt-to'] = [].concat(report['original-rcpt-to'] || []).concat(addresses);
+                report.arf['original-rcpt-to'] = [].concat(report.arf['original-rcpt-to'] || []).concat(addresses);
 
                 let messageId = [].concat(headers['message-id'] || []).pop();
-                if (messageId && !report['message-id']) {
-                    report['message-id'] = messageId;
+                if (messageId && !report.headers['message-id']) {
+                    report.headers['message-id'] = messageId;
                 }
 
                 let sourceIp = [].concat(headers['x-sender-ip'] || []).pop();
                 if (sourceIp && !report['source-ip']) {
-                    report['source-ip'] = sourceIp;
+                    report.arf['source-ip'] = sourceIp;
                 }
 
                 let originalArrivalTime = [].concat(headers['x-ms-exchange-crosstenant-originalarrivaltime'] || []).pop();
-                if (originalArrivalTime && !report['arrival-date']) {
+                if (originalArrivalTime && !report.arf['arrival-date']) {
                     let originalArrivalTimeDate = new Date(originalArrivalTime);
                     if (originalArrivalTimeDate && originalArrivalTimeDate.toString() !== 'Invalid Date') {
-                        report['arrival-date'] = originalArrivalTimeDate.toISOString();
+                        report.arf['arrival-date'] = originalArrivalTimeDate.toISOString();
+                    }
+                }
+
+                for (let headerKey of ['from', 'to', 'cc', 'bcc', 'subject', 'date']) {
+                    let headerLines = []
+                        .concat(headers[headerKey] || [])
+                        .map(val => val && typeof val === 'string' && val.trim())
+                        .filter(val => val);
+                    if (!headerLines.length) {
+                        continue;
+                    }
+
+                    switch (headerKey) {
+                        case 'date':
+                            {
+                                let value = new Date(headerLines.pop());
+                                if (value.toString() !== 'Invalid Date') {
+                                    report.headers[headerKey] = report.headers[headerKey] || value.toISOString();
+                                }
+                            }
+                            break;
+
+                        case 'subject':
+                            {
+                                let value = libmime.decodeWords(headerLines.pop()).trim();
+                                if (value) {
+                                    report.headers[headerKey] = report.headers[headerKey] || value;
+                                }
+                            }
+                            break;
+
+                        case 'from':
+                        case 'to':
+                        case 'cc':
+                        case 'bcc':
+                            {
+                                let value = headerLines
+                                    .flatMap(addressparser)
+                                    .map(entry => entry.address)
+                                    .filter(addr => addr);
+
+                                if (value && value.length) {
+                                    if (headerKey === 'from') {
+                                        value = value.pop();
+                                    }
+                                    report.headers[headerKey] = report.headers[headerKey] || value;
+                                }
+                            }
+                            break;
                     }
                 }
 
@@ -116,15 +168,22 @@ const arfDetect = async messageInfo => {
         }
     }
 
-    let reportDefauls = {};
+    let reportDefauls = {
+        arf: {},
+        headers: {}
+    };
 
     if (!report.source && messageInfo.from && messageInfo.from.address === 'staff@hotmail.com') {
-        reportDefauls.source = 'Hotmail';
-        reportDefauls.feedbackType = reportDefauls.feedbackType || 'abuse';
-        reportDefauls.abuseType = reportDefauls.abuseType || 'complaint';
+        reportDefauls.arf.source = 'Hotmail';
+        reportDefauls.arf['feedback-type'] = reportDefauls.arf['feedback-type'] || 'abuse';
+        reportDefauls.arf['abuse-type'] = reportDefauls.arf['abuse-type'] || 'complaint';
     }
 
-    return Object.assign(reportDefauls, report);
+    for (let key of Object.keys(reportDefauls)) {
+        report[key] = Object.assign(reportDefauls[key], report[key]);
+    }
+
+    return report;
 };
 
 module.exports = { arfDetect };

--- a/lib/mailbox.js
+++ b/lib/mailbox.js
@@ -623,17 +623,25 @@ class Mailbox {
                     });
 
                     if (content) {
-                        attachment.content = (await this.download(content)).toString();
+                        Object.defineProperty(attachment, 'content', {
+                            value: (await this.download(content)).toString(),
+                            enumerable: false
+                        });
                     }
                 }
 
                 const report = await arfDetect(messageInfo);
 
-                if (report && report['original-rcpt-to'] && report['original-rcpt-to'].length) {
+                if (report && report.arf && report.arf['original-rcpt-to'] && report.arf['original-rcpt-to'].length) {
                     // can send report
                     let complaint = {};
-                    for (let key of Object.keys(report)) {
-                        complaint[key.replace(/-(.)/g, (o, c) => c.toUpperCase())] = report[key];
+                    for (let subKey of ['arf', 'headers']) {
+                        for (let key of Object.keys(report[subKey])) {
+                            if (!complaint[subKey]) {
+                                complaint[subKey] = {};
+                            }
+                            complaint[subKey][key.replace(/-(.)/g, (o, c) => c.toUpperCase())] = report[subKey][key];
+                        }
                     }
 
                     complaintNotifyInfo = Object.assign({ complaintMessage: messageInfo.id }, complaint);

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
         "@postalsys/certs": "1.0.2",
         "@postalsys/email-text-tools": "1.0.0",
         "@postalsys/templates": "1.0.1",
-        "ace-builds": "1.11.1",
+        "ace-builds": "1.11.2",
         "base32.js": "0.1.0",
         "bull-arena": "3.29.5",
         "bullmq": "1.87.2",
@@ -102,7 +102,7 @@
     },
     "devDependencies": {
         "eerawlog": "1.4.1",
-        "eslint": "8.23.1",
+        "eslint": "8.24.0",
         "eslint-config-nodemailer": "1.2.0",
         "eslint-config-prettier": "8.5.0",
         "grunt": "1.5.3",

--- a/workers/webhooks.js
+++ b/workers/webhooks.js
@@ -171,7 +171,7 @@ const notifyWorker = new Worker(
             headers.Authorization = `Basic ${Buffer.from(he.encode(username || '') + ':' + he.encode(password || '')).toString('base64')}`;
         }
 
-        if (job.data && job.data.data && job.data.data.text) {
+        if (job.name === 'messageNew' && job.data && job.data.data && job.data.data.text) {
             // normalize text content
             let notifyText = await settings.get('notifyText');
             if (!notifyText) {
@@ -197,7 +197,7 @@ const notifyWorker = new Worker(
             }
         }
 
-        if (job.data && job.data.data && job.data.data.headers) {
+        if (job.name === 'messageNew' && job.data && job.data.data && job.data.data.headers) {
             // normalize headers
             let notifyHeaders = await settings.get('notifyHeaders');
             if (!notifyHeaders) {


### PR DESCRIPTION
* Include report data and original message headers in separate structured objects when sending a webhook about a complaint message