### PR TITLE
Allow to automatically fetch attached images and embed these as data URIs

### DIFF
--- a/lib/mailbox.js
+++ b/lib/mailbox.js
@@ -1512,6 +1512,48 @@ class Mailbox {
                     }
                 }
             }
+
+            if (options.embedAttachedImages && messageInfo.text && messageInfo.text.html && messageInfo.attachments) {
+                let attachmentList = new Map();
+
+                for (let attachment of messageInfo.attachments) {
+                    let contentId = attachment.contentId && attachment.contentId.replace(/^<|>$/g, '');
+                    if (contentId && messageInfo.text.html.indexOf(contentId) >= 0) {
+                        attachmentList.set(contentId, { attachment, content: null });
+                    }
+                }
+
+                for (let { attachment } of attachmentList.values()) {
+                    let buf = Buffer.from(attachment.id, 'base64url');
+                    let part = buf.slice(8).toString();
+                    try {
+                        let { content } = await this.connection.imapClient.download(messageInfo.uid, part, {
+                            uid: true,
+                            chunkSize: options.chunkSize
+                        });
+
+                        if (content) {
+                            Object.defineProperty(attachment, 'content', {
+                                value: await this.download(content),
+                                enumerable: false
+                            });
+                        }
+                    } catch (err) {
+                        this.logger.error({ msg: 'Attachment error', uid: messageInfo.uid, part, err });
+                    }
+                }
+
+                messageInfo.text.html = messageInfo.text.html.replace(/\bcid:<?([^"'\s>]+)/g, (fullMatch, cidMatch) => {
+                    if (attachmentList.has(cidMatch)) {
+                        let { attachment } = attachmentList.get(cidMatch);
+                        if (attachment.content) {
+                            return `data:${attachment.contentType || 'application/octet-stream'};base64,${attachment.content.toString('base64')}`;
+                        }
+                    }
+                    return fullMatch;
+                });
+            }
+
             return messageInfo;
         } finally {
             if (!options.skipLock) {

--- a/workers/api.js
+++ b/workers/api.js
@@ -2789,6 +2789,12 @@ When making API calls remember that requests against the same account are queued
                         .valid('html', 'plain', '*')
                         .example('*')
                         .description('Which text content to return, use * for all. By default text content is not returned.'),
+                    embedAttachedImages: Joi.boolean()
+                        .truthy('Y', 'true', '1')
+                        .falsy('N', 'false', 0)
+                        .default(false)
+                        .description('If true, then fetches attached images and embeds these in the HTML as data URIs')
+                        .label('EmbedImages'),
                     documentStore: documentStoreSchema.default(false)
                 }),
 


### PR DESCRIPTION
Added new query argument to message information requests `embedAttachedImages`.
It allows to automatically fetch attached images and embed these as data URIs

```
curl "http://127.0.0.1:7003/v1/account/example/message/AAAAAQAABvg?textType=*&embedAttachedImages=true"
```