### PR TITLE
Fetch multiple attachments with a single call for embedded images

### DIFF
--- a/lib/mailbox.js
+++ b/lib/mailbox.js
@@ -1515,43 +1515,57 @@ class Mailbox {
 
             if (options.embedAttachedImages && messageInfo.text && messageInfo.text.html && messageInfo.attachments) {
                 let attachmentList = new Map();
+                let partList = [];
 
                 for (let attachment of messageInfo.attachments) {
                     let contentId = attachment.contentId && attachment.contentId.replace(/^<|>$/g, '');
                     if (contentId && messageInfo.text.html.indexOf(contentId) >= 0) {
                         attachmentList.set(contentId, { attachment, content: null });
+
+                        let buf = Buffer.from(attachment.id, 'base64url');
+                        let part = buf.slice(8).toString();
+
+                        Object.defineProperty(attachment, 'part', {
+                            value: part,
+                            enumerable: false
+                        });
+
+                        if (!partList.includes(part)) {
+                            partList.push(part);
+                        }
                     }
                 }
 
-                for (let { attachment } of attachmentList.values()) {
-                    let buf = Buffer.from(attachment.id, 'base64url');
-                    let part = buf.slice(8).toString();
+                if (partList.length) {
                     try {
-                        let { content } = await this.connection.imapClient.download(messageInfo.uid, part, {
-                            uid: true,
-                            chunkSize: options.chunkSize
+                        let contentParts = await this.connection.imapClient.downloadMany(messageInfo.uid, partList, {
+                            uid: true
                         });
 
-                        if (content) {
-                            Object.defineProperty(attachment, 'content', {
-                                value: await this.download(content),
-                                enumerable: false
+                        if (contentParts) {
+                            for (let { attachment } of attachmentList.values()) {
+                                if (attachment.part && contentParts[attachment.part] && contentParts[attachment.part].content) {
+                                    Object.defineProperty(attachment, 'content', {
+                                        value: contentParts[attachment.part].content,
+                                        enumerable: false
+                                    });
+                                }
+                            }
+
+                            messageInfo.text.html = messageInfo.text.html.replace(/\bcid:([^"'\s>]+)/g, (fullMatch, cidMatch) => {
+                                if (attachmentList.has(cidMatch)) {
+                                    let { attachment } = attachmentList.get(cidMatch);
+                                    if (attachment.content) {
+                                        return `data:${attachment.contentType || 'application/octet-stream'};base64,${attachment.content.toString('base64')}`;
+                                    }
+                                }
+                                return fullMatch;
                             });
                         }
                     } catch (err) {
-                        this.logger.error({ msg: 'Attachment error', uid: messageInfo.uid, part, err });
+                        this.logger.error({ msg: 'Attachment error', uid: messageInfo.uid, partList, err });
                     }
                 }
-
-                messageInfo.text.html = messageInfo.text.html.replace(/\bcid:<?([^"'\s>]+)/g, (fullMatch, cidMatch) => {
-                    if (attachmentList.has(cidMatch)) {
-                        let { attachment } = attachmentList.get(cidMatch);
-                        if (attachment.content) {
-                            return `data:${attachment.contentType || 'application/octet-stream'};base64,${attachment.content.toString('base64')}`;
-                        }
-                    }
-                    return fullMatch;
-                });
             }
 
             return messageInfo;

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
         "html-to-text": "8.2.1",
         "humanize": "0.0.9",
         "iconv-lite": "0.6.3",
-        "imapflow": "1.0.108",
+        "imapflow": "1.0.109",
         "ioredis": "5.2.3",
         "ipaddr.js": "2.0.1",
         "joi": "17.6.1",


### PR DESCRIPTION
Instead of fetching all embedded attachments one by one, fetch multiple attachments with a single call for embedded images