### PR TITLE
Added option syncFrom to limit message syncing to ElasticSearch

### DIFF
--- a/lib/account.js
+++ b/lib/account.js
@@ -102,11 +102,16 @@ class Account {
         Object.keys(accountData).forEach(key => {
             switch (key) {
                 case 'notifyFrom':
+                case 'syncFrom':
                     // Date object
                     if (accountData[key]) {
-                        let date = new Date(accountData[key]);
-                        if (date.toString() !== 'Invalid Date') {
-                            result[key] = date;
+                        if (accountData[key] === 'null') {
+                            result[key] = null;
+                        } else {
+                            let date = new Date(accountData[key]);
+                            if (date.toString() !== 'Invalid Date') {
+                                result[key] = date;
+                            }
                         }
                     }
                     break;
@@ -188,6 +193,7 @@ class Account {
         Object.keys(accountData).forEach(key => {
             switch (key) {
                 case 'notifyFrom':
+                case 'syncFrom':
                     // Date object
                     if (accountData[key] === 'now') {
                         result[key] = new Date().toISOString();
@@ -198,6 +204,8 @@ class Account {
                         if (date.toString() !== 'Invalid Date') {
                             result[key] = date.toISOString();
                         }
+                    } else if (accountData[key] === null) {
+                        result[key] = 'null';
                     }
                     break;
 

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -767,6 +767,7 @@ class Connection {
             let accountData = await this.accountObject.loadAccountData();
 
             this.notifyFrom = accountData.notifyFrom;
+            this.syncFrom = accountData.syncFrom;
 
             if ((!accountData.imap && !accountData.oauth2) || (accountData.imap && accountData.imap.disabled)) {
                 // can not make connection

--- a/lib/mailbox.js
+++ b/lib/mailbox.js
@@ -508,12 +508,14 @@ class Mailbox {
                     continue;
                 }
 
-                if (this.connection.notifyFrom && messageData.internalDate < this.connection.notifyFrom && !documentStoreEnabled) {
+                let canSync = documentStoreEnabled && (!this.connection.syncFrom || messageData.internalDate >= this.connection.syncFrom);
+
+                if (this.connection.notifyFrom && messageData.internalDate < this.connection.notifyFrom && !canSync) {
                     // skip too old messages
                     continue;
                 }
 
-                await this.processNew(messageData, messageFetchOptions, documentStoreEnabled);
+                await this.processNew(messageData, messageFetchOptions, canSync);
             }
 
             if (hadUpdates) {
@@ -566,7 +568,7 @@ class Mailbox {
         }
     }
 
-    async processNew(messageData, options, documentStoreEnabled) {
+    async processNew(messageData, options, canSync) {
         this.logger.debug({ msg: 'New message', uid: messageData.uid, flags: Array.from(messageData.flags) });
 
         options.skipLock = true;
@@ -635,7 +637,7 @@ class Mailbox {
         }
 
         let date = new Date(messageInfo.date);
-        if (this.connection.notifyFrom && date < this.connection.notifyFrom && !documentStoreEnabled) {
+        if (this.connection.notifyFrom && date < this.connection.notifyFrom && !canSync) {
             // skip too old messages
             return;
         }
@@ -1198,12 +1200,14 @@ class Mailbox {
                     continue;
                 }
 
-                if (this.connection.notifyFrom && messageData.internalDate < this.connection.notifyFrom && !documentStoreEnabled) {
+                let canSync = documentStoreEnabled && (!this.connection.syncFrom || messageData.internalDate >= this.connection.syncFrom);
+
+                if (this.connection.notifyFrom && messageData.internalDate < this.connection.notifyFrom && !canSync) {
                     // skip too old messages
                     continue;
                 }
 
-                await this.processNew(messageData, messageFetchOptions, documentStoreEnabled);
+                await this.processNew(messageData, messageFetchOptions, canSync);
             }
 
             if (hadUpdates) {

--- a/lib/routes-ui.js
+++ b/lib/routes-ui.js
@@ -3763,6 +3763,10 @@ ${Buffer.from(data.content, 'base64url').toString('base64')}
                 };
             }
 
+            if (data.syncFrom) {
+                accountData.syncFrom = data.syncFrom;
+            }
+
             const oAuth2Client = await getOAuth2Client(request.payload.type);
             let nonce = crypto.randomBytes(12).toString('hex');
 
@@ -4178,7 +4182,7 @@ ${Buffer.from(data.content, 'base64url').toString('base64')}
 
             data = JSON.parse(data);
 
-            let accountData = {
+            const accountData = {
                 account: data.account,
                 name: request.payload.name || data.name,
                 email: request.payload.email,
@@ -4186,6 +4190,8 @@ ${Buffer.from(data.content, 'base64url').toString('base64')}
                 tz: request.payload.tz,
 
                 notifyFrom: new Date(),
+
+                syncFrom: data.syncFrom || null,
 
                 imap: {
                     host: request.payload.imap_host,
@@ -4208,13 +4214,13 @@ ${Buffer.from(data.content, 'base64url').toString('base64')}
                 }
             };
 
-            let accountObject = new Account({ redis, call, secret: await getSecret() });
-            let result = await accountObject.create(accountData);
+            const accountObject = new Account({ redis, call, secret: await getSecret() });
+            const result = await accountObject.create(accountData);
 
             let httpRedirectUrl;
             if (data.redirectUrl) {
-                let serviceUrl = await settings.get('serviceUrl');
-                let url = new URL(data.redirectUrl, serviceUrl);
+                const serviceUrl = await settings.get('serviceUrl');
+                const url = new URL(data.redirectUrl, serviceUrl);
                 url.searchParams.set('account', result.account);
                 url.searchParams.set('state', result.state);
                 httpRedirectUrl = url.href;

--- a/lib/schemas.js
+++ b/lib/schemas.js
@@ -864,10 +864,25 @@ const messageUpdateSchema = Joi.object({
         .label('LabelUpdate')
 }).label('MessageUpdate');
 
+const accountSchemas = {
+    syncFrom: Joi.date()
+        .iso()
+        .allow(null)
+        .example('2021-07-08T07:06:34.336Z')
+        .description('Sync messages to document store starting from provided date. If not set, all emails are synced.'),
+
+    notifyFrom: Joi.date()
+        .iso()
+        .allow(null)
+        .example('2021-07-08T07:06:34.336Z')
+        .description('Send webhooks for messages starting from provided date. The default is the account creation date.')
+};
+
 module.exports = {
     ADDRESS_STRATEGIES,
 
     settingsSchema,
+    accountSchemas,
     addressSchema,
     settingsQuerySchema,
     imapSchema,

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -1216,6 +1216,7 @@ MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEV3QUiYsp13nD9suD1/ZkEXnuMoSg
                           account: opts.account,
                           name: opts.name,
                           email: opts.email,
+                          syncFrom: (opts.syncFrom && opts.syncFrom.toISOString()) || null,
                           redirectUrl: opts.redirectUrl
                       }
             )

--- a/workers/api.js
+++ b/workers/api.js
@@ -119,7 +119,8 @@ const {
     templateSchemas,
     documentStoreSchema,
     searchSchema,
-    messageUpdateSchema
+    messageUpdateSchema,
+    accountSchemas
 } = require('../lib/schemas');
 
 const DEFAULT_EENGINE_TIMEOUT = 10 * 1000;
@@ -1775,7 +1776,8 @@ When making API calls remember that requests against the same account are queued
 
                     logs: Joi.boolean().example(false).description('Store recent logs').default(false),
 
-                    notifyFrom: Joi.date().iso().example('2021-07-08T07:06:34.336Z').description('Notify messages from date').default('now'),
+                    notifyFrom: accountSchemas.notifyFrom.default('now'),
+                    syncFrom: accountSchemas.syncFrom.default(null),
 
                     proxy: settingsSchema.proxyUrl,
 
@@ -1810,6 +1812,7 @@ When making API calls remember that requests against the same account are queued
                     account: request.payload.account,
                     name: request.payload.name,
                     email: request.payload.email,
+                    syncFrom: request.payload.syncFrom,
                     redirectUrl: request.payload.redirectUrl
                 });
 
@@ -1902,6 +1905,8 @@ When making API calls remember that requests against the same account are queued
 
                     name: Joi.string().empty('').max(256).example('My Email Account').description('Display name for the account'),
                     email: Joi.string().empty('').email().example('user@example.com').description('Default email address of the account'),
+
+                    syncFrom: accountSchemas.syncFrom,
 
                     redirectUrl: Joi.string()
                         .empty('')
@@ -2002,7 +2007,8 @@ When making API calls remember that requests against the same account are queued
 
                     logs: Joi.boolean().example(false).description('Store recent logs'),
 
-                    notifyFrom: Joi.date().iso().example('2021-07-08T07:06:34.336Z').description('Notify messages from date'),
+                    notifyFrom: accountSchemas.notifyFrom,
+                    syncFrom: accountSchemas.syncFrom,
 
                     proxy: settingsSchema.proxyUrl,
 
@@ -2340,6 +2346,7 @@ When making API calls remember that requests against the same account are queued
                     'email',
                     'copy',
                     'notifyFrom',
+                    'syncFrom',
                     'imap',
                     'smtp',
                     'oauth2',
@@ -2410,7 +2417,8 @@ When making API calls remember that requests against the same account are queued
                     copy: Joi.boolean().example(true).description('Copy submitted messages to Sent folder'),
                     logs: Joi.boolean().example(false).description('Store recent logs'),
 
-                    notifyFrom: Joi.date().iso().example('2021-07-08T07:06:34.336Z').description('Notify messages from date'),
+                    notifyFrom: accountSchemas.notifyFrom,
+                    syncFrom: accountSchemas.syncFrom,
 
                     webhooks: Joi.string()
                         .uri({


### PR DESCRIPTION
* new account setup option `syncFrom` (date value). If not set, then EmailEngine will sync only these emails to ES that have internal date newer than `syncFrom` value