### PR TITLE
fix ES mapper parsing exception with unknown [enabled] parameter

### DIFF
--- a/lib/es.js
+++ b/lib/es.js
@@ -250,7 +250,7 @@ const mappings = {
 
     preview: {
         type: 'text',
-        enabled: false
+        index: false
     },
 
     text: {


### PR DESCRIPTION
EmailEngine v2.26.9
Node.js v16.17.1
Redis v7.0.5
ImapFlow v1.0.110
ELK v4.2.0

#### Steps to reproduce this issue:

1. Create new clear instance of EmailEngine
2. Enable DocumentStore
3. Add new email account
4. Check ES logs

There will be ``MapperParsingException`` with message ``Failed to parse mapping: unknown parameter [enabled] on mapper [preview] of type [text]``


I've replaced ``enabled`` with ``index``, because ``enabled`` can apply only to objects and ``index`` applies to all other data types

[Current ES docs - Mapping - Index](https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-index.html)
[Current ES docs - Mapping - Enabled](https://www.elastic.co/guide/en/elasticsearch/reference/current/enabled.html)