### PR TITLE
If TLS for SMTP is disabled, remove STARTTLS option

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
         "ace-builds": "1.11.2",
         "base32.js": "0.1.0",
         "bull-arena": "3.29.5",
-        "bullmq": "2.3.0",
+        "bullmq": "2.3.1",
         "compare-versions": "5.0.1",
         "dotenv": "16.0.3",
         "encoding-japanese": "2.0.0",

--- a/workers/smtp.js
+++ b/workers/smtp.js
@@ -414,6 +414,9 @@ async function init() {
                 serverOptions.key = certificateData.privateKey;
             }
         }
+    } else {
+        serverOptions.disabledCommands = ['STARTTLS'];
+        serverOptions.hideSTARTTLS = true;
     }
 
     server = new SMTPServer(serverOptions);


### PR DESCRIPTION
If TLS for SMTP is disabled, remove STARTTLS option