### PR TITLE
Fix deleted folder handling for Document Store

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ on:
     push:
         branches:
             - master
-            - fix-network-scan
+            - docstore-mailbox-delete
 
 name: Deploy test instance
 

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -53,7 +53,8 @@ const {
     MESSAGE_DELETED_NOTIFY,
     MESSAGE_UPDATED_NOTIFY,
     EMAIL_BOUNCE_NOTIFY,
-    DEFAULT_DOWNLOAD_CHUNK_SIZE
+    DEFAULT_DOWNLOAD_CHUNK_SIZE,
+    MAILBOX_DELETED_NOTIFY
 } = require('./consts');
 
 const DOWNLOAD_CHUNK_SIZE = getByteSize(readEnvValue('EENGINE_CHUNK_SIZE')) || DEFAULT_DOWNLOAD_CHUNK_SIZE;
@@ -687,7 +688,7 @@ class Connection {
 
         let addDocumentQueueJob =
             this.documentsQueue &&
-            [MESSAGE_NEW_NOTIFY, MESSAGE_DELETED_NOTIFY, MESSAGE_UPDATED_NOTIFY, EMAIL_BOUNCE_NOTIFY].includes(event) &&
+            [MESSAGE_NEW_NOTIFY, MESSAGE_DELETED_NOTIFY, MESSAGE_UPDATED_NOTIFY, EMAIL_BOUNCE_NOTIFY, MAILBOX_DELETED_NOTIFY].includes(event) &&
             (await settings.get('documentStoreEnabled'));
 
         const defaultJobOptions = {

--- a/lib/routes-ui.js
+++ b/lib/routes-ui.js
@@ -849,7 +849,6 @@ function applyRoutes(server, call) {
                 enableApiProxy: (await settings.get('enableApiProxy')) || false,
                 trackSentMessages: (await settings.get('trackSentMessages')) || false,
                 resolveGmailCategories: (await settings.get('resolveGmailCategories')) || false,
-                labsDocumentStore: (await settings.get('labsDocumentStore')) || (await settings.get('documentStoreEnabled')) || false,
                 labsMailRu: (await settings.get('labsMailRu')) || (await settings.get('mailRuEnabled')) || false,
                 enableOAuthTokensApi: (await settings.get('enableOAuthTokensApi')) || false,
                 locale: (await settings.get('locale')) || false,
@@ -892,7 +891,6 @@ function applyRoutes(server, call) {
                     enableApiProxy: request.payload.enableApiProxy,
                     trackSentMessages: request.payload.trackSentMessages,
                     resolveGmailCategories: request.payload.resolveGmailCategories,
-                    labsDocumentStore: request.payload.labsDocumentStore,
                     labsMailRu: request.payload.labsMailRu,
                     enableOAuthTokensApi: request.payload.enableOAuthTokensApi,
                     locale: request.payload.locale,
@@ -914,11 +912,7 @@ function applyRoutes(server, call) {
                     await settings.set(key, data[key]);
                 }
 
-                if (!data.labsDocumentStore && (await settings.get('documentStoreEnabled'))) {
-                    await settings.set('documentStoreEnabled', false);
-                }
-
-                if (!data.labsDocumentStore && (await settings.get('mailRuEnabled'))) {
+                if (!data.labsMailRu && (await settings.get('mailRuEnabled'))) {
                     await settings.set('mailRuEnabled', false);
                 }
 
@@ -1005,11 +999,6 @@ function applyRoutes(server, call) {
                     resolveGmailCategories: settingsSchema.resolveGmailCategories.default(false),
 
                     // Following options can only be changed via the UI
-                    labsDocumentStore: Joi.boolean()
-                        .truthy('Y', 'true', '1', 'on')
-                        .falsy('N', 'false', 0, '')
-                        .description('If true, then allow using the Document Store')
-                        .default(false),
                     labsMailRu: Joi.boolean()
                         .truthy('Y', 'true', '1', 'on')
                         .falsy('N', 'false', 0, '')

--- a/views/config/document-store.hbs
+++ b/views/config/document-store.hbs
@@ -1,21 +1,19 @@
 <div class="d-sm-flex align-items-center justify-content-between mb-1">
     <h1 class="h3 mb-0 text-gray-800">
         <small><i class="fas fa-database fa-fw"></i></small>
-        Document Store <span class="badge badge-dark">beta</span></label>
+        Document Store</label>
     </h1>
 </div>
 
 <p class="mb-4">
-    EmailEngine can sync emails to a document store for local processing. Currently only ElasticSearch is supported.
+    EmailEngine can sync emails to a document store for local processing. Currently only ElasticSearch v8+ is supported.
 </p>
 
-<div class="card border-left-info shadow mb-4">
+<div class="card border-left-warning shadow mb-4">
     <div class="card-body">
         <div class="row no-gutters align-items-center">
             <div class="col mr-2">
 
-                <p>Document Store is in beta, which means the application might change in the future without a
-                    possible migration path.</p>
                 <p>Syncing emails and changes to the Document Store is <em>best effort</em>. EmailEngine might miss
                     some data. Email attachments are not stored in the Document Store.</p>
                 <p>Enable Document Store before adding any accounts. Otherwise, emails that have been already

--- a/views/config/document-store.hbs
+++ b/views/config/document-store.hbs
@@ -21,7 +21,12 @@
                         EmailEngine might miss some data.</li>
                     <li>Email attachments are not stored in the Document Store.</li>
                     <li>Enable Document Store before adding any accounts that need to be indexed. Emails that are
-                        processed while Document Store is <em>not enabled</em> will not be added to the Document Store.
+                        processed while Document Store is not enabled <em>will not be synced</em> to the Document Store.
+                    </li>
+                    <li>You <em>can</em> modify entries stored in the Document Store. Adding new fields is allowed.
+                        Changing existing field values is allowed if you do not change the type. Do not modify system
+                        fields <code>_id</code>, <code>id</code>, <code>account</code>, <code>uid</code> and
+                        <code>path</code>.
                     </li>
                 </ul>
             </div>

--- a/views/config/document-store.hbs
+++ b/views/config/document-store.hbs
@@ -6,7 +6,7 @@
 </div>
 
 <p class="mb-4">
-    EmailEngine can sync emails to a document store for local processing. Currently only ElasticSearch v8+ is supported.
+    EmailEngine can sync emails to a document store for local processing.
 </p>
 
 <div class="card border-left-warning shadow mb-4">
@@ -14,15 +14,20 @@
         <div class="row no-gutters align-items-center">
             <div class="col mr-2">
 
-                <p>Syncing emails and changes to the Document Store is <em>best effort</em>. EmailEngine might miss
-                    some data. Email attachments are not stored in the Document Store.</p>
-                <p>Enable Document Store before adding any accounts. Otherwise, emails that have been already
-                    processed will not be indexed.</p>
-
+                <ul>
+                    <li>Only ElasticSearch v8+ is supported as a Document Store backend. Older versions of
+                        ElasticSearch and alternatives like OpenSearch are not supported.</li>
+                    <li>Syncing emails to the Document Store is not transactional but <em>best effort</em>.
+                        EmailEngine might miss some data.</li>
+                    <li>Email attachments are not stored in the Document Store.</li>
+                    <li>Enable Document Store before adding any accounts that need to be indexed. Emails that are
+                        processed while Document Store is <em>not enabled</em> will not be added to the Document Store.
+                    </li>
+                </ul>
             </div>
 
             <div class="col-auto">
-                <i class="fas fa-exclamation-circle fa-2x text-gray-300"></i>
+                <i class="fas fa-exclamation-triangle fa-2x text-gray-300"></i>
             </div>
         </div>
     </div>

--- a/views/config/service.hbs
+++ b/views/config/service.hbs
@@ -307,19 +307,6 @@
 
             <div class="form-group form-check">
                 <div class="text-muted float-right code-link">[<em>Web UI only</em>]</div>
-                <input type="checkbox" class="form-check-input {{#if errors.labsDocumentStore}}is-invalid{{/if}}"
-                    id="labsDocumentStore" name="labsDocumentStore" {{#if values.labsDocumentStore}}checked{{/if}} />
-                <label class="form-check-label" for="labsDocumentStore">Allow to use Document Store</label>
-                {{#if errors.labsDocumentStore}}
-                <span class="invalid-feedback">{{errors.labsDocumentStore}}</span>
-                {{/if}}
-                <small class="form-text text-muted">Document Store allows to sync messages to external storage
-                    (ElasticSearch). Enabling this option will add a new configuration menu option you can
-                    use to set up document store syncing.</small>
-            </div>
-
-            <div class="form-group form-check">
-                <div class="text-muted float-right code-link">[<em>Web UI only</em>]</div>
                 <input type="checkbox" class="form-check-input {{#if errors.labsMailRu}}is-invalid{{/if}}"
                     id="labsMailRu" name="labsMailRu" {{#if values.labsMailRu}}checked{{/if}} />
                 <label class="form-check-label" for="labsMailRu">Allow to use OAuth2 with Mail.ru</label>

--- a/views/partials/side_menu.hbs
+++ b/views/partials/side_menu.hbs
@@ -97,11 +97,9 @@
                 </div>
             </a>
 
-            {{#if showDocumentStore}}
             <a class="collapse-item {{#if menuConfigDocumentStore}}active{{/if}}"
-                href="/admin/config/document-store">Document Store <span
-                    class="badge badge-dark">beta</span></label></a>
-            {{/if}}
+                href="/admin/config/document-store">Document Store</label></a>
+
         </div>
     </div>
 </li>

--- a/workers/api.js
+++ b/workers/api.js
@@ -136,7 +136,6 @@ const DEFAULT_MAX_BODY_SIZE = 50 * 1024 * 1024;
 const { OUTLOOK_SCOPES } = require('../lib/outlook-oauth');
 const { GMAIL_SCOPES } = require('../lib/gmail-oauth');
 const { MAIL_RU_SCOPES } = require('../lib/mail-ru-oauth');
-const { homedir } = require('os');
 
 const REDACTED_KEYS = ['req.headers.authorization', 'req.headers.cookie'];
 

--- a/workers/api.js
+++ b/workers/api.js
@@ -6624,7 +6624,7 @@ When making API calls remember that requests against the same account are queued
                 systemAlerts,
                 embeddedTemplateHeader: await settings.get('templateHeader'),
                 currentYear: new Date().getFullYear(),
-                showDocumentStore: (await settings.get('labsDocumentStore')) || (await settings.get('documentStoreEnabled')),
+                showDocumentStore: await settings.get('documentStoreEnabled'),
                 showMailRu: (await settings.get('labsMailRu')) || (await settings.get('mailRuEnabled'))
             };
         }


### PR DESCRIPTION
* If a mailbox folder is deleted, remove entries from Document Store
* If an account is deleted, clear account entries from the threads index
* Remove the beta label from Document Store settings