### PR TITLE
Do not throw when listing messages from a missing mailbox folder

### DIFF
--- a/lib/account.js
+++ b/lib/account.js
@@ -853,7 +853,7 @@ class Account {
                         },
                         {
                             term: {
-                                labels: mailboxData.specialUse || path
+                                labels: (mailboxData && mailboxData.specialUse) || path
                             }
                         }
                     ],
@@ -981,7 +981,7 @@ class Account {
                             },
                             {
                                 term: {
-                                    labels: mailboxData.specialUse || path
+                                    labels: (mailboxData && mailboxData.specialUse) || path
                                 }
                             }
                         ],


### PR DESCRIPTION
Do not throw when listing messages from a missing mailbox folder