### PR TITLE
Hotmail message ID

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ on:
     push:
         branches:
             - master
-            - oauth2-apps
+            - hotmail-message-id
 
 name: Deploy test instance
 

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -1798,7 +1798,7 @@ class Connection {
             let originalMessageId;
 
             // Hotmail
-            let hotmailMessageIdMatch = (info.response || '').toString().match(/^250 2.0.0 OK <([^>]+\.prod\.outlook\.com)>/);
+            let hotmailMessageIdMatch = (info.response || '').toString().match(/^250 2.0.0 OK (<[^>]+\.prod\.outlook\.com>)/);
             if (hotmailMessageIdMatch && hotmailMessageIdMatch[1] !== info.messageId) {
                 // MessageId was overriden
                 originalMessageId = info.messageId;

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -1793,13 +1793,28 @@ class Connection {
                 await this.redis.hSetExists(this.getAccountKey(), 'smtpServerEhlo', JSON.stringify(info.ehlo));
             }
 
+            // special rules for MTA servers
+
+            let originalMessageId;
+
+            // Hotmail
+            let hotmailMessageIdMatch = (info.response || '').toString().match(/^250 2.0.0 OK <([^>]+\.prod\.outlook\.com)>/);
+            if (hotmailMessageIdMatch && hotmailMessageIdMatch[1] !== info.messageId) {
+                // MessageId was overriden
+                originalMessageId = info.messageId;
+                info.messageId = hotmailMessageIdMatch[1];
+            }
+
+            // done
+
             try {
                 // try to update
                 await submitJobEntry.updateProgress({
                     status: 'smtp-completed',
 
                     response: info.response,
-                    messageId: info.messageId
+                    messageId: info.messageId,
+                    originalMessageId
                 });
             } catch (err) {
                 // ignore
@@ -1807,6 +1822,7 @@ class Connection {
 
             await this.notify(false, EMAIL_SENT_NOTIFY, {
                 messageId: info.messageId,
+                originalMessageId,
                 response: info.response,
                 queueId,
                 envelope

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
         "ace-builds": "1.14.0",
         "base32.js": "0.1.0",
         "bull-arena": "3.30.3",
-        "bullmq": "3.5.7",
+        "bullmq": "3.5.8",
         "compare-versions": "5.0.3",
         "dotenv": "16.0.3",
         "encoding-japanese": "2.0.0",


### PR DESCRIPTION
If message-id is changed by the SMTP server, and the client is informed about it, then use the updated value as `messageId` in webhooks, and `originalMessageId` for the original value