### PR TITLE
Changed Redis reconnect backoff to delay at least 1 second

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -47,7 +47,7 @@ const REDIS_CONF = Object.assign(
         maxRetriesPerRequest: null,
         showFriendlyErrorStack: true,
         retryStrategy(times) {
-            const delay = !times ? 50 : Math.min(2 ** times * 50, 10 * 1000);
+            const delay = !times ? 1000 : Math.min(2 ** times * 500, 15 * 1000);
             logger.trace({ msg: 'Connection retry', times, delay });
             return delay;
         },


### PR DESCRIPTION
Changed Redis reconnect backoff to delay at least 1 second. See https://github.com/luin/ioredis/issues/1718

New retry times are 1, 1, 2, 4, 8, 14, 15, ...15 seconds