### PR TITLE
Added support for subconnections to monitor changes on secondary mailboxes

### DIFF
--- a/lib/account.js
+++ b/lib/account.js
@@ -133,6 +133,18 @@ class Account {
                     result[key] = accountData[key] === 'true' ? true : false;
                     break;
 
+                case 'subconnections':
+                    try {
+                        let value = JSON.parse(accountData[key]);
+                        if (value === null) {
+                            break;
+                        }
+                        result[key] = value;
+                    } catch (err) {
+                        this.logger.error({ msg: 'Failed to parse input from Redis', key, value: accountData[key], err });
+                    }
+                    break;
+
                 case 'imap':
                 case 'smtp':
                 case 'imapServerInfo':
@@ -228,6 +240,14 @@ class Account {
                         }
                     } else if (accountData[key] === null) {
                         result[key] = 'null';
+                    }
+                    break;
+
+                case 'subconnections':
+                    try {
+                        result[key] = JSON.stringify(accountData[key]);
+                    } catch (err) {
+                        this.logger.error({ msg: 'Failed to stringify input for Redis', key, err });
                     }
                     break;
 
@@ -414,16 +434,39 @@ class Account {
             throw error;
         }
 
-        if ('imap' in accountData) {
-            // if partial update, then skip check
+        let reconnectRequested = false;
+
+        if ('imap' in accountData && !reconnectRequested) {
             try {
                 deepStrictEqual(oldAccountData.imap, accountData.imap);
+            } catch (err) {
+                // changes detected!
+                reconnectRequested = true;
+            }
+        }
+
+        if ('path' in accountData && !reconnectRequested) {
+            try {
                 strictEqual(oldAccountData.path || '*', accountData.path || '*');
             } catch (err) {
                 // changes detected!
-                this.logger.info({ msg: 'IMAP configuration changed for account', account: this.account });
-                await this.call({ cmd: 'update', account: this.account });
+                reconnectRequested = true;
             }
+        }
+
+        if ('subconnections' in accountData && !reconnectRequested) {
+            try {
+                deepStrictEqual(oldAccountData.subconnections, accountData.subconnections);
+            } catch (err) {
+                // changes detected!
+                reconnectRequested = true;
+            }
+        }
+
+        if (reconnectRequested) {
+            // changes detected!
+            this.logger.info({ msg: 'IMAP configuration changed for account', account: this.account });
+            await this.call({ cmd: 'update', account: this.account });
         }
 
         return {

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -540,6 +540,10 @@ class Connection {
         this._connecting = true;
         this.isClosed = false;
 
+        if (force) {
+            this.closeSubconnections();
+        }
+
         try {
             await backOff(() => this.start(), {
                 maxDelay: MAX_BACKOFF_DELAY,
@@ -818,10 +822,13 @@ class Connection {
         }
     }
 
-    async getImapConfig(accountData) {
+    async getImapConfig(accountData, ctx) {
         if (!accountData) {
             accountData = await this.accountObject.loadAccountData();
         }
+
+        // the same method is also called by subconnections, so do not mark the primary connection as failing if something happens
+        ctx = ctx || this;
 
         let imapConnectionConfig;
         if (accountData.oauth2 && accountData.oauth2.auth) {
@@ -842,12 +849,12 @@ class Connection {
                     if (err.tokenRequest) {
                         notifyData.tokenRequest = err.tokenRequest;
                     }
-                    await this.notify(false, AUTH_ERROR_NOTIFY, notifyData);
-                    this.logger.error({
+                    await ctx.notify(false, AUTH_ERROR_NOTIFY, notifyData);
+                    ctx.logger.error({
                         account: this.account,
                         err
                     });
-                    this.state = AUTH_ERROR_NOTIFY;
+                    ctx.state = AUTH_ERROR_NOTIFY;
                     throw err;
                 }
             } else {
@@ -881,15 +888,15 @@ class Connection {
                 imapConnectionConfig.auth = await resolveCredentials(this.account, 'imap');
             } catch (err) {
                 err.authenticationFailed = true;
-                await this.notify(false, AUTH_ERROR_NOTIFY, {
+                await ctx.notify(false, AUTH_ERROR_NOTIFY, {
                     response: err.message,
                     serverResponseCode: 'HTTPRequestError'
                 });
-                this.logger.error({
+                ctx.logger.error({
                     account: this.account,
                     err
                 });
-                this.state = AUTH_ERROR_NOTIFY;
+                ctx.state = AUTH_ERROR_NOTIFY;
                 throw err;
             }
         }
@@ -1145,16 +1152,7 @@ class Connection {
         this.isClosing = false;
         this.isClosed = true;
 
-        for (let i = this.subconnections.length - 1; i >= 0; i--) {
-            let subconnection = this.subconnections[i];
-            this.subconnections.splice(i, 1);
-
-            try {
-                subconnection.close();
-            } catch (err) {
-                this.logger.error({ msg: 'Failed to close subconnection', path: subconnection && subconnection.path, err });
-            }
-        }
+        this.closeSubconnections();
     }
 
     isConnected() {
@@ -2961,7 +2959,8 @@ class Connection {
                 // not listed anymore
                 this.subconnections.splice(i, 1);
                 try {
-                    await subconnection.close();
+                    subconnection.removeAllListeners();
+                    subconnection.close();
                 } catch (err) {
                     this.logger.error({ msg: 'Failed to close unlisted subconnection', path: subconnection.path, err });
                 }
@@ -2983,8 +2982,43 @@ class Connection {
                     subconnection: mailbox.path
                 })
             });
+            this.subconnections.push(subconnection);
+
+            subconnection.on('changes', path => {
+                let mailbox;
+
+                if (this.mailboxes.has(normalizePath(path))) {
+                    mailbox = this.mailboxes.get(normalizePath(path));
+                    try {
+                        mailbox
+                            .sync()
+                            .then(() => this.ensureMainMailbox())
+                            .catch(err => {
+                                this.logger.error({ msg: 'Failed to sync mailbox', path, err });
+                            });
+                    } catch (err) {
+                        this.logger.error({ msg: 'Failed to sync mailbox', path, err });
+                    }
+                }
+            });
 
             await subconnection.init();
+        }
+    }
+
+    closeSubconnections() {
+        // remove unneeded
+        for (let i = this.subconnections.length - 1; i >= 0; i--) {
+            let subconnection = this.subconnections[i];
+
+            // not listed anymore
+            this.subconnections.splice(i, 1);
+            try {
+                subconnection.removeAllListeners();
+                subconnection.close();
+            } catch (err) {
+                this.logger.error({ msg: 'Failed to close unlisted subconnection', path: subconnection.path, err });
+            }
         }
     }
 

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -25,6 +25,8 @@ const { inlineHtml, inlineText, htmlToText } = require('@postalsys/email-text-to
 const uuid = require('uuid');
 const { oauth2Apps, oauth2ProviderData } = require('./oauth2-apps');
 
+const { Subconnection } = require('./subconnection');
+
 const { getSignedFormDataSync, getServiceSecret } = require('./tools');
 
 const {
@@ -40,8 +42,6 @@ const {
 const RESYNC_DELAY = 15 * 60;
 const ENSURE_MAIN_TTL = 5 * 1000;
 
-const MAX_BACKOFF_DELAY = 10 * 60 * 1000; // 10 min
-
 const {
     AUTH_ERROR_NOTIFY,
     AUTH_SUCCESS_NOTIFY,
@@ -55,7 +55,8 @@ const {
     MESSAGE_UPDATED_NOTIFY,
     EMAIL_BOUNCE_NOTIFY,
     DEFAULT_DOWNLOAD_CHUNK_SIZE,
-    MAILBOX_DELETED_NOTIFY
+    MAILBOX_DELETED_NOTIFY,
+    MAX_BACKOFF_DELAY
 } = require('./consts');
 
 const DOWNLOAD_CHUNK_SIZE = getByteSize(readEnvValue('EENGINE_CHUNK_SIZE')) || DEFAULT_DOWNLOAD_CHUNK_SIZE;
@@ -130,6 +131,8 @@ class Connection {
         this.idCache = new Map();
 
         this.defaultDelimiter = '/';
+
+        this.subconnections = [];
 
         this.state = 'connecting';
     }
@@ -382,7 +385,7 @@ class Connection {
                     !this.mailboxes.has(normalizePath(entry.path))
                 ) {
                     if (accountData.path && accountData.path !== '*') {
-                        if (accountData.path !== entry.path) {
+                        if (accountData.path !== entry.path && accountData.path !== entry.specialUse) {
                             // ignore changes
                             entry.syncDisabled = true;
                         }
@@ -432,7 +435,7 @@ class Connection {
 
         for (let entry of listing) {
             if (accountData.path && accountData.path !== '*') {
-                if (accountData.path !== entry.path) {
+                if (accountData.path !== entry.path && accountData.path !== entry.specialUse) {
                     entry.syncDisabled = true;
                 } else {
                     this.main = entry;
@@ -815,6 +818,123 @@ class Connection {
         }
     }
 
+    async getImapConfig(accountData) {
+        if (!accountData) {
+            accountData = await this.accountObject.loadAccountData();
+        }
+
+        let imapConnectionConfig;
+        if (accountData.oauth2 && accountData.oauth2.auth) {
+            // load OAuth2 tokens
+            let now = Date.now();
+            let accessToken;
+            if (!accountData.oauth2.accessToken || !accountData.oauth2.expires || accountData.oauth2.expires < new Date(now - 30 * 1000)) {
+                // renew access token
+                try {
+                    accountData = await this.accountObject.renewAccessToken();
+                    accessToken = accountData.oauth2.accessToken;
+                } catch (err) {
+                    err.authenticationFailed = true;
+                    let notifyData = {
+                        response: err.message,
+                        serverResponseCode: 'OauthRenewError'
+                    };
+                    if (err.tokenRequest) {
+                        notifyData.tokenRequest = err.tokenRequest;
+                    }
+                    await this.notify(false, AUTH_ERROR_NOTIFY, notifyData);
+                    this.logger.error({
+                        account: this.account,
+                        err
+                    });
+                    this.state = AUTH_ERROR_NOTIFY;
+                    throw err;
+                }
+            } else {
+                accessToken = accountData.oauth2.accessToken;
+            }
+
+            const oauth2App = await oauth2Apps.get(accountData.oauth2.provider);
+            if (!oauth2App) {
+                throw new Error('Missing or disabled OAuth2 app');
+            }
+            const providerData = oauth2ProviderData(oauth2App.provider);
+
+            imapConnectionConfig = Object.assign(
+                {
+                    auth: {
+                        user: accountData.oauth2.auth.user,
+                        accessToken
+                    },
+                    resyncDelay: 900
+                },
+                providerData.imap || {}
+            );
+        } else {
+            // deep copy of imap settings
+            imapConnectionConfig = JSON.parse(JSON.stringify(accountData.imap));
+        }
+
+        // If authentication server is set then it overrides authentication data
+        if (imapConnectionConfig.useAuthServer) {
+            try {
+                imapConnectionConfig.auth = await resolveCredentials(this.account, 'imap');
+            } catch (err) {
+                err.authenticationFailed = true;
+                await this.notify(false, AUTH_ERROR_NOTIFY, {
+                    response: err.message,
+                    serverResponseCode: 'HTTPRequestError'
+                });
+                this.logger.error({
+                    account: this.account,
+                    err
+                });
+                this.state = AUTH_ERROR_NOTIFY;
+                throw err;
+            }
+        }
+
+        if (!imapConnectionConfig.tls) {
+            imapConnectionConfig.tls = {};
+        }
+        imapConnectionConfig.tls.localAddress = (await this.getLocalAddress('imap')).localAddress;
+
+        // reload log config
+        await this.accountLogger.reload();
+
+        let imapConfig = Object.assign(
+            {
+                resyncDelay: RESYNC_DELAY,
+                id: this.cid,
+                emitLogs: this.accountLogger.enabled
+            },
+            imapConnectionConfig,
+            this.imapConfig
+        );
+        this.resyncDelay = imapConfig.resyncDelay * 1000;
+
+        // set up proxy if needed
+        if (accountData.proxy) {
+            imapConfig.proxy = accountData.proxy;
+        } else {
+            let proxyUrl = await settings.get('proxyUrl');
+            let proxyEnabled = await settings.get('proxyEnabled');
+            if (proxyEnabled && proxyUrl && !imapConfig.proxy) {
+                imapConfig.proxy = proxyUrl;
+            }
+        }
+
+        if (/(\.rambler\.ru|\.163\.com)$/i.test(imapConfig.host)) {
+            // Special case for Rambler and 163. Break IDLE at least once a minute
+            imapConfig.maxIdleTime = 55 * 1000;
+        } else if (/\.yahoo\.com$/i.test(imapConfig.host)) {
+            // Special case for Yahoo. Break IDLE at least once every three minutes
+            imapConfig.maxIdleTime = 3 * 60 * 1000;
+        }
+
+        return imapConfig;
+    }
+
     async start() {
         let initialState = this.state;
 
@@ -845,116 +965,9 @@ class Connection {
                 return;
             }
 
-            let imapConnectionConfig;
-            if (accountData.oauth2 && accountData.oauth2.auth) {
-                // load OAuth2 tokens
-                let now = Date.now();
-                let accessToken;
-                if (!accountData.oauth2.accessToken || !accountData.oauth2.expires || accountData.oauth2.expires < new Date(now - 30 * 1000)) {
-                    // renew access token
-                    try {
-                        accountData = await this.accountObject.renewAccessToken();
-                        accessToken = accountData.oauth2.accessToken;
-                    } catch (err) {
-                        err.authenticationFailed = true;
-                        let notifyData = {
-                            response: err.message,
-                            serverResponseCode: 'OauthRenewError'
-                        };
-                        if (err.tokenRequest) {
-                            notifyData.tokenRequest = err.tokenRequest;
-                        }
-                        await this.notify(false, AUTH_ERROR_NOTIFY, notifyData);
-                        this.logger.error({
-                            account: this.account,
-                            err
-                        });
-                        this.state = AUTH_ERROR_NOTIFY;
-                        throw err;
-                    }
-                } else {
-                    accessToken = accountData.oauth2.accessToken;
-                }
-
-                const oauth2App = await oauth2Apps.get(accountData.oauth2.provider);
-                if (!oauth2App) {
-                    throw new Error('Missing or disabled OAuth2 app');
-                }
-                const providerData = oauth2ProviderData(oauth2App.provider);
-
-                imapConnectionConfig = Object.assign(
-                    {
-                        auth: {
-                            user: accountData.oauth2.auth.user,
-                            accessToken
-                        },
-                        resyncDelay: 900
-                    },
-                    providerData.imap || {}
-                );
-            } else {
-                // deep copy of imap settings
-                imapConnectionConfig = JSON.parse(JSON.stringify(accountData.imap));
-            }
-
-            // If authentication server is set then it overrides authentication data
-            if (imapConnectionConfig.useAuthServer) {
-                try {
-                    imapConnectionConfig.auth = await resolveCredentials(this.account, 'imap');
-                } catch (err) {
-                    err.authenticationFailed = true;
-                    await this.notify(false, AUTH_ERROR_NOTIFY, {
-                        response: err.message,
-                        serverResponseCode: 'HTTPRequestError'
-                    });
-                    this.logger.error({
-                        account: this.account,
-                        err
-                    });
-                    this.state = AUTH_ERROR_NOTIFY;
-                    throw err;
-                }
-            }
-
-            if (!imapConnectionConfig.tls) {
-                imapConnectionConfig.tls = {};
-            }
-            imapConnectionConfig.tls.localAddress = (await this.getLocalAddress('imap')).localAddress;
-
-            // reload log config
-            await this.accountLogger.reload();
-
-            let imapConfig = Object.assign(
-                {
-                    resyncDelay: RESYNC_DELAY,
-                    id: this.cid,
-                    emitLogs: this.accountLogger.enabled
-                },
-                imapConnectionConfig,
-                this.imapConfig
-            );
-            this.resyncDelay = imapConfig.resyncDelay * 1000;
-
-            // set up proxy if needed
-            if (accountData.proxy) {
-                imapConfig.proxy = accountData.proxy;
-            } else {
-                let proxyUrl = await settings.get('proxyUrl');
-                let proxyEnabled = await settings.get('proxyEnabled');
-                if (proxyEnabled && proxyUrl && !imapConfig.proxy) {
-                    imapConfig.proxy = proxyUrl;
-                }
-            }
+            let imapConfig = await this.getImapConfig(accountData);
 
             imapConfig.expungeHandler = async payload => await this.expungeHandler(payload);
-
-            if (/(\.rambler\.ru|\.163\.com)$/i.test(imapConfig.host)) {
-                // Special case for Rambler and 163. Break IDLE at least once a minute
-                imapConfig.maxIdleTime = 55 * 1000;
-            } else if (/\.yahoo\.com$/i.test(imapConfig.host)) {
-                // Special case for Yahoo. Break IDLE at least once every three minutes
-                imapConfig.maxIdleTime = 3 * 60 * 1000;
-            }
 
             this.imapClient = new ImapFlow(imapConfig);
 
@@ -994,6 +1007,8 @@ class Connection {
                 await this.notify(false, AUTH_SUCCESS_NOTIFY, {
                     user: imapConfig.auth.user
                 });
+
+                await this.setupSubConnections();
             } catch (err) {
                 if (err.oauthError && err.oauthError.status === 'invalid_request') {
                     // access token is invalid, clear it
@@ -1111,7 +1126,7 @@ class Connection {
         this.logger.info({ msg: 'Closed account', account: this.account });
     }
 
-    async close() {
+    close() {
         this.state = 'disconnected';
         if (this.isClosed || this.isClosing) {
             return;
@@ -1129,6 +1144,17 @@ class Connection {
 
         this.isClosing = false;
         this.isClosed = true;
+
+        for (let i = this.subconnections.length - 1; i >= 0; i--) {
+            let subconnection = this.subconnections[i];
+            this.subconnections.splice(i, 1);
+
+            try {
+                subconnection.close();
+            } catch (err) {
+                this.logger.error({ msg: 'Failed to close subconnection', path: subconnection && subconnection.path, err });
+            }
+        }
     }
 
     isConnected() {
@@ -1490,7 +1516,7 @@ class Connection {
                         !this.mailboxes.has(normalizePath(entry.path))
                     ) {
                         if (accountData.path && accountData.path !== '*') {
-                            if (accountData.path !== entry.path) {
+                            if (accountData.path !== entry.path && accountData.path !== entry.specialUse) {
                                 // ignore changes
                                 entry.syncDisabled = true;
                             }
@@ -2912,6 +2938,56 @@ class Connection {
         }
     }
 
+    async setupSubConnections() {
+        let accountData = await this.accountObject.loadAccountData();
+
+        let mailboxes = [];
+
+        let listing = await this.getCurrentListing();
+
+        for (let path of accountData.subconnections || []) {
+            let entry = listing.find(entry => path === entry.path || path === entry.specialUse);
+            if (this.isGmail && (!accountData.path || accountData.path === '*') && !['\\Trash', '\\Junk'].includes(entry.specialUse)) {
+                // no need to check this folder, as \All already covers it
+                continue;
+            }
+            mailboxes.push(entry);
+        }
+
+        // remove unneeded
+        for (let i = this.subconnections.length - 1; i >= 0; i--) {
+            let subconnection = this.subconnections[i];
+            if (!mailboxes.find(mailbox => mailbox.path === subconnection.path)) {
+                // not listed anymore
+                this.subconnections.splice(i, 1);
+                try {
+                    await subconnection.close();
+                } catch (err) {
+                    this.logger.error({ msg: 'Failed to close unlisted subconnection', path: subconnection.path, err });
+                }
+            }
+        }
+
+        // create missing
+        for (let mailbox of mailboxes) {
+            if (this.subconnections.find(subconnection => mailbox.path === subconnection.path)) {
+                // already exists
+                continue;
+            }
+            // create new
+            let subconnection = new Subconnection({
+                account: this.account,
+                mailbox,
+                getImapConfig: async () => await this.getImapConfig(),
+                logger: this.logger.child({
+                    subconnection: mailbox.path
+                })
+            });
+
+            await subconnection.init();
+        }
+    }
+
     getLogger() {
         this.mainLogger =
             this.options.logger ||
@@ -2944,6 +3020,9 @@ class Connection {
                 }
             };
         }
+
+        synteticLogger.child = opts => this.mainLogger.child(opts);
+
         return synteticLogger;
     }
 }

--- a/lib/consts.js
+++ b/lib/consts.js
@@ -105,6 +105,8 @@ module.exports = {
     // Default value for the CORS Access-Control-Max-Age header
     DEFAULT_CORS_MAX_AGE: 60,
 
+    MAX_BACKOFF_DELAY: 10 * 60 * 1000, // 10 min
+
     generateWebhookTable() {
         let entries = [];
 

--- a/lib/routes-ui.js
+++ b/lib/routes-ui.js
@@ -5665,6 +5665,18 @@ ${Buffer.from(data.content, 'base64url').toString('base64')}
                 throw error;
             }
 
+            let subConnectionInfo;
+            try {
+                subConnectionInfo = await call({ cmd: 'subconnections', account: request.params.account });
+                for (let subconnection of subConnectionInfo) {
+                    formatAccountData(subconnection);
+                }
+            } catch (err) {
+                subConnectionInfo = {
+                    err
+                };
+            }
+
             if (accountData && accountData.oauth2 && accountData.oauth2.provider) {
                 let oauth2App = await oauth2Apps.get(accountData.oauth2.provider);
                 if (oauth2App) {
@@ -5768,6 +5780,8 @@ ${Buffer.from(data.content, 'base64url').toString('base64')}
                     }),
 
                     showAdvanced: accountData.path || accountData.proxy || accountData.webhooks,
+
+                    subConnectionInfo,
 
                     capabilities
                 },

--- a/lib/subconnection.js
+++ b/lib/subconnection.js
@@ -2,11 +2,15 @@
 
 const { ImapFlow } = require('imapflow');
 const { backOff } = require('exponential-backoff');
+const EventEmitter = require('events').EventEmitter;
 
 const { MAX_BACKOFF_DELAY } = require('./consts');
 
-class Subconnection {
+const MAX_WAIT_DELAY = 450; //ms
+
+class Subconnection extends EventEmitter {
     constructor(opts) {
+        super();
         opts = opts || {};
         this.mailbox = opts.mailbox || {};
         this.path = this.mailbox.path;
@@ -19,6 +23,10 @@ class Subconnection {
         this.isClosing = false;
         this.isClosed = false;
         this._connecting = false;
+
+        this.state = 'connecting';
+
+        this.emitTimer = false;
     }
 
     isConnected() {
@@ -32,6 +40,15 @@ class Subconnection {
             err.statusCode = 503;
             throw err;
         }
+    }
+
+    requestSync() {
+        clearTimeout(this.emitTimer);
+        this.emitTimer = setTimeout(() => {
+            clearTimeout(this.emitTimer);
+
+            this.emit('changes', this.path);
+        }, MAX_WAIT_DELAY);
     }
 
     async init() {
@@ -61,6 +78,8 @@ class Subconnection {
         try {
             await this.checkIMAPConnection();
             await this.imapClient.mailboxOpen(this.mailbox.path);
+
+            this.state = 'connected';
         } catch (err) {
             // ended in an unconncted state
             this.logger.error({ msg: 'Failed to set up subconnection', err });
@@ -84,7 +103,7 @@ class Subconnection {
             }
         }
 
-        let imapConfig = await this.getImapConfig();
+        let imapConfig = await this.getImapConfig(null, this);
 
         imapConfig.expungeHandler = async payload => await this.expungeHandler(payload);
         imapConfig.logger = this.logger;
@@ -98,7 +117,18 @@ class Subconnection {
             });
         });
 
-        await this.connect();
+        try {
+            await this.connect();
+        } catch (err) {
+            if (err.authenticationFailed) {
+                this.logger.error({ msg: 'Failed to authenticate subconnection', account: this.account, err });
+                this.state = 'authenticationError';
+            } else {
+                this.logger.error({ msg: 'Failed to connect subconnection', account: this.account, err });
+                this.state = 'connectError';
+            }
+            throw err;
+        }
     }
 
     async connect() {
@@ -118,6 +148,8 @@ class Subconnection {
             }
 
             this.logger.info({ msg: 'Exists notification', account: this.account, event });
+
+            this.requestSync();
         });
 
         imapClient.on('flags', async event => {
@@ -126,6 +158,8 @@ class Subconnection {
             }
 
             this.logger.info({ msg: 'Flags notification', account: this.account, event });
+
+            this.requestSync();
         });
 
         imapClient.on('close', async () => {
@@ -145,9 +179,17 @@ class Subconnection {
 
     async expungeHandler(payload) {
         this.logger.info({ msg: 'Expunge notification', account: this.account, payload });
+
+        this.requestSync();
+    }
+
+    async notify() {
+        // no op
     }
 
     close() {
+        this.state = 'disconnected';
+
         if (this.isClosed || this.isClosing) {
             return;
         }

--- a/lib/subconnection.js
+++ b/lib/subconnection.js
@@ -1,0 +1,170 @@
+'use strict';
+
+const { ImapFlow } = require('imapflow');
+const { backOff } = require('exponential-backoff');
+
+const { MAX_BACKOFF_DELAY } = require('./consts');
+
+class Subconnection {
+    constructor(opts) {
+        opts = opts || {};
+        this.mailbox = opts.mailbox || {};
+        this.path = this.mailbox.path;
+        this.logger = opts.logger;
+        this.account = opts.account;
+
+        this.imapClient = null;
+        this.getImapConfig = opts.getImapConfig;
+
+        this.isClosing = false;
+        this.isClosed = false;
+        this._connecting = false;
+    }
+
+    isConnected() {
+        return this.imapClient && this.imapClient.usable && !this.isClosing && !this.isClosed;
+    }
+
+    checkIMAPConnection() {
+        if (!this.isConnected()) {
+            let err = new Error('IMAP connection is currently not available for requested account');
+            err.code = 'IMAPUnavailable';
+            err.statusCode = 503;
+            throw err;
+        }
+    }
+
+    async init() {
+        this.logger.info({ msg: 'Creating subconnection' });
+        await this.reconnect();
+    }
+
+    async reconnect(force) {
+        if (this._connecting || this.isClosing || (this.isClosed && !force)) {
+            return false;
+        }
+
+        this._connecting = true;
+        this.isClosed = false;
+
+        try {
+            await backOff(() => this.start(), {
+                maxDelay: MAX_BACKOFF_DELAY,
+                numOfAttempts: Infinity,
+                retry: () => !this.isClosing && !this.isClosed,
+                startingDelay: 2000
+            });
+        } finally {
+            this._connecting = false;
+        }
+
+        try {
+            await this.checkIMAPConnection();
+            await this.imapClient.mailboxOpen(this.mailbox.path);
+        } catch (err) {
+            // ended in an unconncted state
+            this.logger.error({ msg: 'Failed to set up subconnection', err });
+        }
+    }
+
+    async start() {
+        if (this.imapClient) {
+            // close previous
+            this.imapClient.disabled = true;
+            try {
+                this.imapClient.removeAllListeners();
+                this.imapClient.on('error', err => {
+                    this.logger.error({ msg: 'IMAP connection error', previous: true, account: this.account, err });
+                });
+                this.imapClient.close();
+            } catch (err) {
+                this.logger.error({ msg: 'IMAP close error', err });
+            } finally {
+                this.imapClient = null;
+            }
+        }
+
+        let imapConfig = await this.getImapConfig();
+
+        imapConfig.expungeHandler = async payload => await this.expungeHandler(payload);
+        imapConfig.logger = this.logger;
+
+        this.imapClient = new ImapFlow(imapConfig);
+
+        this.imapClient.on('error', err => {
+            this.logger.error({ msg: 'IMAP connection error', account: this.account, err });
+            this.reconnect().catch(err => {
+                this.logger.error({ msg: 'IMAP reconnection error', account: this.account, err });
+            });
+        });
+
+        await this.connect();
+    }
+
+    async connect() {
+        if (this.isClosing || this.isClosed) {
+            return false;
+        }
+
+        let imapClient = this.imapClient;
+
+        // throws if connection fails
+        let response = await imapClient.connect();
+
+        // Process untagged EXISTS responses
+        imapClient.on('exists', async event => {
+            if (!event || !event.path) {
+                return; //?
+            }
+
+            this.logger.info({ msg: 'Exists notification', account: this.account, event });
+        });
+
+        imapClient.on('flags', async event => {
+            if (!event || !event.path) {
+                return; //?
+            }
+
+            this.logger.info({ msg: 'Flags notification', account: this.account, event });
+        });
+
+        imapClient.on('close', async () => {
+            this.logger.info({ msg: 'Connection closed', account: this.account });
+
+            try {
+                if (!imapClient.disabled) {
+                    await this.reconnect();
+                }
+            } catch (err) {
+                this.logger.error({ msg: 'Connection close error', err });
+            }
+        });
+
+        return response;
+    }
+
+    async expungeHandler(payload) {
+        this.logger.info({ msg: 'Expunge notification', account: this.account, payload });
+    }
+
+    close() {
+        if (this.isClosed || this.isClosing) {
+            return;
+        }
+        this.isClosing = true;
+
+        if (this.imapClient) {
+            this.imapClient.close();
+        }
+
+        clearTimeout(this.refreshListingTimer);
+        clearTimeout(this.untaggedExpungeTimer);
+        clearTimeout(this.resyncTimer);
+        clearTimeout(this.completedTimer);
+
+        this.isClosing = false;
+        this.isClosed = true;
+    }
+}
+
+module.exports = { Subconnection };

--- a/server.js
+++ b/server.js
@@ -1362,6 +1362,15 @@ async function onCommand(worker, message) {
 
             return await call(assignedWorker, message, transferList);
         }
+
+        case 'subconnections': {
+            if (!assigned.has(message.account)) {
+                return [];
+            }
+
+            let assignedWorker = assigned.get(message.account);
+            return await call(assignedWorker, message, []);
+        }
     }
     return 999;
 }

--- a/views/accounts/account.hbs
+++ b/views/accounts/account.hbs
@@ -307,6 +307,32 @@
 
         </dl>
 
+        {{#if subConnectionInfo}}
+        <hr>
+        <h6 class="font-weight-bold text-primary">Subconnections</h6>
+
+        <p>Subconnections are additional IMAP connections to detect changes in secondary folders. EmailEngine, by
+            default, receives updates only for the primary folder and needs to poll secondary folders, but in some
+            cases, information is needed faster and without delay.</p>
+
+        <dl class="row mt-3">
+            {{#each subConnectionInfo}}
+            <dt class="col-sm-3">{{path}}</dt>
+            <dd class="col-sm-9">
+                <span class="badge badge-pill badge-{{stateLabel.type}} state-info" style="cursor:default;"
+                    data-toggle="popover" data-trigger="hover" {{#if stateLabel.error}}data-title="Connection error"
+                    data-content="{{stateLabel.error}}" {{/if}}>
+
+                    {{#if stateLabel.spinner}}
+                    <i class="fas fa-spinner fa-spin fa-fw"></i>
+                    {{/if}}
+
+                    {{stateLabel.name}}</span>
+            </dd>
+            {{/each}}
+        </dl>
+        {{/if}}
+
     </div>
     <div class="card-footer">
 

--- a/workers/api.js
+++ b/workers/api.js
@@ -1887,6 +1887,15 @@ When making API calls remember that requests against the same account are queued
 
                     path: Joi.string().empty('').max(1024).default('*').example('INBOX').description('Check changes only on selected path'),
 
+                    subconnections: Joi.array()
+                        .items(Joi.string().max(256))
+                        .single()
+                        .example(['[Gmail]/Spam', '\\Sent'])
+                        .description(
+                            'An array of mailbox paths. If set, then EmailEngine opens additional IMAP connections against these paths to detect changes faster. NB! connection counts are usually highly limited.'
+                        )
+                        .label('SubconnectionPaths'),
+
                     webhooks: Joi.string()
                         .uri({
                             scheme: ['http', 'https'],
@@ -2116,6 +2125,15 @@ When making API calls remember that requests against the same account are queued
                     email: Joi.string().empty('').email().example('user@example.com').description('Default email address of the account'),
 
                     path: Joi.string().empty('').max(1024).default('*').example('INBOX').description('Check changes only on selected path'),
+
+                    subconnections: Joi.array()
+                        .items(Joi.string().max(256))
+                        .single()
+                        .example(['[Gmail]/Spam', '\\Sent'])
+                        .description(
+                            'An array of mailbox paths. If set, then EmailEngine opens additional IMAP connections against these paths to detect changes faster. NB! connection counts are usually highly limited.'
+                        )
+                        .label('SubconnectionPaths'),
 
                     webhooks: Joi.string()
                         .uri({
@@ -2478,6 +2496,8 @@ When making API calls remember that requests against the same account are queued
                     'oauth2',
                     'state',
                     'smtpStatus',
+                    'path',
+                    'subconnections',
                     'webhooks',
                     'proxy',
                     'locale',
@@ -2545,6 +2565,17 @@ When making API calls remember that requests against the same account are queued
 
                     notifyFrom: accountSchemas.notifyFrom,
                     syncFrom: accountSchemas.syncFrom,
+
+                    path: Joi.string().empty('').max(1024).default('*').example('INBOX').description('Check changes only on selected path'),
+
+                    subconnections: Joi.array()
+                        .items(Joi.string().max(256))
+                        .single()
+                        .example(['[Gmail]/Spam', '\\Sent'])
+                        .description(
+                            'An array of mailbox paths. If set, then EmailEngine opens additional IMAP connections against these paths to detect changes faster. NB! connection counts are usually highly limited.'
+                        )
+                        .label('SubconnectionPaths'),
 
                     webhooks: Joi.string()
                         .uri({

--- a/workers/imap.js
+++ b/workers/imap.js
@@ -372,6 +372,22 @@ class ConnectionHandler {
         return await accountData.connection.queueMessage(message.data, message.meta);
     }
 
+    async subconnections(message) {
+        if (!this.accounts.has(message.account)) {
+            return [];
+        }
+
+        const accountObject = this.accounts.get(message.account);
+        if (!accountObject.connection) {
+            return [];
+        }
+
+        return accountObject.connection.subconnections.map(subconnection => ({
+            path: subconnection.path,
+            state: subconnection.state
+        }));
+    }
+
     async uploadMessage(message) {
         if (!this.accounts.has(message.account)) {
             return NO_ACTIVE_HANDLER_RESP;
@@ -555,6 +571,7 @@ class ConnectionHandler {
             case 'submitMessage':
             case 'queueMessage':
             case 'uploadMessage':
+            case 'subconnections':
                 return await this[message.cmd](message);
 
             case 'countConnections': {

--- a/workers/imap.js
+++ b/workers/imap.js
@@ -487,9 +487,9 @@ class ConnectionHandler {
         logger.error({ msg: 'Terminating process' });
         this.killed = true;
 
-        this.accounts.forEach(account => {
-            if (account.connection) {
-                account.connection.close();
+        this.accounts.forEach(accountObject => {
+            if (accountObject && accountObject.connection) {
+                accountObject.connection.close();
             }
         });
 


### PR DESCRIPTION
Allow creating "probe" IMAP connections that notify the primary connection for changes on monitored secondary mailbox folders