### PR TITLE
Added data.messageSpecialUse property to messageNew webhooks

### DIFF
--- a/lib/mailbox.js
+++ b/lib/mailbox.js
@@ -792,6 +792,7 @@ class Mailbox {
                 uid: messageData.uid,
                 id: messageInfo.id
             });
+
             for (let category of ['primary', 'social', 'promotions', 'updates', 'forums', 'reservations', 'purchases']) {
                 try {
                     let results = await this.connection.imapClient.search(

--- a/lib/webhooks.js
+++ b/lib/webhooks.js
@@ -490,6 +490,15 @@ ${webhookData.content.map}
             }
         }
 
+        if (event === 'messageNew' && payload) {
+            for (let specialUseTag of ['\\Junk', '\\Sent', '\\Trash', '\\Inbox']) {
+                if (payload.specialUse === specialUseTag || (payload.data && payload.data.labels && payload.data.labels.includes(specialUseTag))) {
+                    payload.data.messageSpecialUse = specialUseTag;
+                    break;
+                }
+            }
+        }
+
         return payload;
     }
 


### PR DESCRIPTION
Added data.messageSpecialUse property to messageNew webhooks.

This allows easier categorizing of emails (`\Inbox` vs `\Sent`) as the folder might be `\All` for both