### PR TITLE
Increase UID and sequence search length limit from 256B to 8kB

### DIFF
--- a/lib/schemas.js
+++ b/lib/schemas.js
@@ -848,7 +848,9 @@ const documentStoreSchema = Joi.boolean()
     .label('UseDocumentStore');
 
 const searchSchema = Joi.object({
-    seq: Joi.string().max(256).description('Sequence number range. Not allowed with `documentStore`.'),
+    seq: Joi.string()
+        .max(8 * 1024)
+        .description('Sequence number range. Not allowed with `documentStore`.'),
 
     answered: Joi.boolean().truthy('Y', 'true', '1').falsy('N', 'false', 0).description('Check if message is answered or not').label('AnsweredFlag'),
     deleted: Joi.boolean()
@@ -885,7 +887,10 @@ const searchSchema = Joi.object({
         .description('Matches messages smaller than value')
         .label('MessageSmaller'),
 
-    uid: Joi.string().max(256).description('UID range').label('UIDRange'),
+    uid: Joi.string()
+        .max(8 * 1024)
+        .description('UID range')
+        .label('UIDRange'),
 
     modseq: Joi.number().min(0).description('Matches messages with modseq higher than value. Not allowed with `documentStore`.').label('ModseqLarger'),
 

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
         "grunt-eslint": "24.0.1",
         "jsxgettext": "0.11.0",
         "pino-pretty": "9.4.0",
-        "pkg": "5.8.0",
+        "pkg": "5.8.1",
         "xgettext-template": "4.1.2"
     },
     "engines": {


### PR DESCRIPTION
Increase UID and sequence search length limit from 256B to 8kB