### PR TITLE
Make sure that account id defaults to null

### DIFF
--- a/workers/api.js
+++ b/workers/api.js
@@ -1139,6 +1139,10 @@ When making API calls remember that requests against the same account are queued
                 throw error;
             }
 
+            if (!accountData.account) {
+                accountData.account = null;
+            }
+
             const accountMeta = accountData._meta || {};
             delete accountData._meta;
 


### PR DESCRIPTION
Make sure that account id defaults to null to prevent error response if account id is not set