### PR TITLE
Fix duplicates in swagger config

### DIFF
--- a/lib/schemas.js
+++ b/lib/schemas.js
@@ -829,7 +829,7 @@ const lastErrorSchema = Joi.object({
             .description('OAuth2 client ID used to authenticate this request'),
         scopes: Joi.array()
             .items(Joi.string().example('https://mail.google.com/').label('ScopeEntry').description('OAuth2 scope'))
-            .description('List of requested OAuth2 scopes'),
+            .description('List of requested OAuth2 scopes').label('OauthScopes'),
         response: Joi.object()
             .example({
                 error: 'invalid_grant',

--- a/workers/api.js
+++ b/workers/api.js
@@ -1914,9 +1914,9 @@ When making API calls remember that requests against the same account are queued
 
                     proxy: settingsSchema.proxyUrl,
 
-                    imap: Joi.object(imapSchema).allow(false).description('IMAP configuration').label('IMAP'),
+                    imap: Joi.object(imapSchema).allow(false).description('IMAP configuration').label('ImapConfiguration'),
 
-                    smtp: Joi.object(smtpSchema).allow(false).description('SMTP configuration').label('SMTP'),
+                    smtp: Joi.object(smtpSchema).allow(false).description('SMTP configuration').label('SmtpConfiguration'),
 
                     oauth2: Joi.object(oauth2Schema).allow(false).description('OAuth2 configuration').label('OAuth2'),
 
@@ -4880,8 +4880,8 @@ When making API calls remember that requests against the same account are queued
 
                 payload: Joi.object({
                     mailboxes: Joi.boolean().example(false).description('Include mailbox listing in response').default(false),
-                    imap: Joi.object(imapSchema).allow(false).description('IMAP configuration').label('IMAP'),
-                    smtp: Joi.object(smtpSchema).allow(false).description('SMTP configuration').label('SMTP'),
+                    imap: Joi.object(imapSchema).allow(false).description('IMAP configuration').label('ImapConfiguration'),
+                    smtp: Joi.object(smtpSchema).allow(false).description('SMTP configuration').label('SmtpConfiguration'),
                     proxy: settingsSchema.proxyUrl
                 }).label('VerifyAccount')
             },


### PR DESCRIPTION
When Using tools to generate an SDK based on the Swagger config, there are issues given some fields are duplicated, this solves by:

- Removing the conflict of `SMTP` and `smtp` by renaming `SMTP` to `SmtpConfiguration` (and his references).
- Removing the conflict of `IMAP` and `imap` by renaming `IMAP` to `ImapConfiguration` (and his references).
- Removing the conflict of `Scopes` and `scopes` by renaming `scopes` to `OauthScopes` (and his references).