### PR TITLE
Remove preview property from message details

### DIFF
--- a/lib/account.js
+++ b/lib/account.js
@@ -903,13 +903,13 @@ class Account {
                 case '*':
                     break;
                 case 'html':
-                    reqOpts._source_excludes = 'text.plain';
+                    reqOpts._source_excludes += ',text.plain';
                     break;
                 case 'plain':
-                    reqOpts._source_excludes = 'text.html';
+                    reqOpts._source_excludes += ',text.html';
                     break;
                 default:
-                    reqOpts._source_excludes = 'text.plain,text.html';
+                    reqOpts._source_excludes += ',text.plain,text.html';
             }
 
             let getResult = await client.get(reqOpts);


### PR DESCRIPTION
Make sure that preview property is filtered out when requesting message details from ElasticSearch