### PR TITLE
Allow configuring EHLO hostname for SMTP greetings

### DIFF
--- a/lib/account.js
+++ b/lib/account.js
@@ -94,6 +94,7 @@ class Account {
                 syncTime: accountData.sync,
                 webhooks: accountData.webhooks || undefined,
                 proxy: accountData.proxy || undefined,
+                smtpEhloName: accountData.smtpEhloName || undefined,
                 lastError:
                     accountData.state === 'connected' || !accountData.lastErrorState || !Object.keys(accountData.lastErrorState).length
                         ? null

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -14,7 +14,6 @@ const MailComposer = require('nodemailer/lib/mail-composer');
 const util = require('util');
 const { getRawEmail, removeBcc } = require('./get-raw-email');
 const { deepEqual } = require('assert');
-const net = require('net');
 const os = require('os');
 const socks = require('socks');
 const { getTemplate } = require('@postalsys/templates');
@@ -29,13 +28,13 @@ const { getThread } = require('./threads');
 
 const { Subconnection } = require('./subconnection');
 
-const { getSignedFormDataSync, getServiceSecret } = require('./tools');
-
 const {
+    getSignedFormDataSync,
+    getServiceSecret,
+    getLocalAddress,
     normalizePath,
     resolveCredentials,
     emitChangeEvent,
-    selectRendezvousAddress,
     convertDataUrisToAtachments,
     getByteSize,
     getBoolean,
@@ -839,60 +838,6 @@ class Connection {
         }
     }
 
-    async getLocalAddress(protocol) {
-        let existingAddresses = Object.values(os.networkInterfaces())
-            .flatMap(entry => entry)
-            .map(entry => entry.address);
-
-        let addressStartegy = await settings.get(`${protocol}Strategy`);
-        let localAddresses = []
-            .concat((await settings.get(`localAddresses`)) || [])
-            .filter(address => existingAddresses.includes(address))
-            .filter(address => net.isIPv4(address));
-        let localAddress;
-
-        let serviceUrl = (await settings.get('serviceUrl')) || null;
-        let hostname = serviceUrl ? (new URL(serviceUrl).hostname || '').toString().toLowerCase().trim() : os.hostname();
-        if (hostname) {
-            try {
-                hostname = punycode.toASCII(hostname);
-            } catch (err) {
-                // ignore
-            }
-        }
-
-        if (!localAddresses.length) {
-            return { address: false, name: hostname };
-        } else if (localAddresses.length === 1) {
-            localAddress = localAddresses[0];
-        } else {
-            switch (addressStartegy) {
-                case 'random': {
-                    localAddress = localAddresses[Math.floor(Math.random() * localAddresses.length)];
-                    break;
-                }
-                case 'dedicated':
-                    localAddress = selectRendezvousAddress(this.account, localAddresses);
-                    break;
-                default:
-                    return { address: false, name: hostname };
-            }
-        }
-
-        if (!localAddress) {
-            return { address: false, name: hostname };
-        }
-
-        try {
-            let addressData = JSON.parse(await redis.hget(`${REDIS_PREFIX}interfaces`, localAddress));
-            addressData.name = addressData.name || hostname;
-            return addressData;
-        } catch (err) {
-            this.logger.error({ msg: 'Failed to load address data', localAddress, err });
-            return { address: false, name: hostname };
-        }
-    }
-
     async getImapConfig(accountData, ctx) {
         if (!accountData) {
             accountData = await this.accountObject.loadAccountData();
@@ -977,7 +922,7 @@ class Connection {
         if (!imapConnectionConfig.tls) {
             imapConnectionConfig.tls = {};
         }
-        imapConnectionConfig.tls.localAddress = (await this.getLocalAddress('imap')).localAddress;
+        imapConnectionConfig.tls.localAddress = (await getLocalAddress(redis, 'imap', this.account)).localAddress;
 
         for (let key of Object.keys(TLS_DEFAULTS)) {
             if (!(key in imapConnectionConfig.tls)) {
@@ -1849,7 +1794,7 @@ class Connection {
             }
         }
 
-        let { localAddress: address, name } = await this.getLocalAddress('smtp');
+        let { localAddress: address, name } = await getLocalAddress(redis, 'smtp', this.account);
 
         let smtpLogger = {};
         let smtpSettings = Object.assign(
@@ -1908,6 +1853,10 @@ class Connection {
             if (proxyEnabled && proxyUrl && !smtpSettings.proxy) {
                 smtpSettings.proxy = proxyUrl;
             }
+        }
+
+        if (accountData.smtpEhloName) {
+            smtpSettings.name = accountData.smtpEhloName;
         }
 
         const submitJobEntry = await this.submitQueue.getJob(jobData.id);

--- a/lib/imapproxy/imap-server.js
+++ b/lib/imapproxy/imap-server.js
@@ -5,11 +5,8 @@ const { parentPort } = require('worker_threads');
 const config = require('wild-config');
 const logger = require('../logger');
 const { oauth2Apps, oauth2ProviderData } = require('../oauth2-apps');
-const os = require('os');
-const punycode = require('punycode/');
-const net = require('net');
 
-const { getDuration, getBoolean, resolveCredentials, hasEnvValue, readEnvValue, selectRendezvousAddress, emitChangeEvent, matchIp } = require('../tools');
+const { getDuration, getBoolean, resolveCredentials, hasEnvValue, readEnvValue, emitChangeEvent, matchIp, getLocalAddress } = require('../tools');
 
 const { redis } = require('../db');
 const { Account } = require('../account');
@@ -124,60 +121,6 @@ class PassThroughLogger extends PassThrough {
 
     _flush(next) {
         next();
-    }
-}
-
-async function getLocalAddress(protocol, account) {
-    let existingAddresses = Object.values(os.networkInterfaces())
-        .flatMap(entry => entry)
-        .map(entry => entry.address);
-
-    let addressStartegy = await settings.get(`${protocol}Strategy`);
-    let localAddresses = []
-        .concat((await settings.get(`localAddresses`)) || [])
-        .filter(address => existingAddresses.includes(address))
-        .filter(address => net.isIPv4(address));
-    let localAddress;
-
-    let serviceUrl = (await settings.get('serviceUrl')) || null;
-    let hostname = serviceUrl ? (new URL(serviceUrl).hostname || '').toString().toLowerCase().trim() : os.hostname();
-    if (hostname) {
-        try {
-            hostname = punycode.toASCII(hostname);
-        } catch (err) {
-            // ignore
-        }
-    }
-
-    if (!localAddresses.length) {
-        return { address: false, name: hostname };
-    } else if (localAddresses.length === 1) {
-        localAddress = localAddresses[0];
-    } else {
-        switch (addressStartegy) {
-            case 'random': {
-                localAddress = localAddresses[Math.floor(Math.random() * localAddresses.length)];
-                break;
-            }
-            case 'dedicated':
-                localAddress = selectRendezvousAddress(account, localAddresses);
-                break;
-            default:
-                return { address: false, name: hostname };
-        }
-    }
-
-    if (!localAddress) {
-        return { address: false, name: hostname };
-    }
-
-    try {
-        let addressData = JSON.parse(await redis.hget(`${REDIS_PREFIX}interfaces`, localAddress));
-        addressData.name = addressData.name || hostname;
-        return addressData;
-    } catch (err) {
-        logger.error({ msg: 'Failed to load address data', localAddress, err });
-        return { address: false, name: hostname };
     }
 }
 
@@ -336,7 +279,7 @@ async function onAuth(auth, session) {
     if (!imapConnectionConfig.tls) {
         imapConnectionConfig.tls = {};
     }
-    imapConnectionConfig.tls.localAddress = (await getLocalAddress('imap', account)).localAddress;
+    imapConnectionConfig.tls.localAddress = (await getLocalAddress(redis, 'imap', account)).localAddress;
 
     // reload log config
 

--- a/lib/routes-ui.js
+++ b/lib/routes-ui.js
@@ -6,7 +6,17 @@ const settings = require('./settings');
 const tokens = require('./tokens');
 const Joi = require('joi');
 const logger = require('./logger');
-const { failAction, verifyAccountInfo, getLogs, flattenObjectKeys, getStats, getBoolean, getSignedFormData, readEnvValue } = require('./tools');
+const {
+    failAction,
+    verifyAccountInfo,
+    getLogs,
+    flattenObjectKeys,
+    getStats,
+    getBoolean,
+    getSignedFormData,
+    readEnvValue,
+    getServiceHostname
+} = require('./tools');
 const packageData = require('../package.json');
 const he = require('he');
 const crypto = require('crypto');
@@ -4133,7 +4143,7 @@ return payload;`)
                     }
                 };
 
-                let verifyResult = await verifyAccountInfo(accountData);
+                let verifyResult = await verifyAccountInfo(redis, accountData);
 
                 if (verifyResult) {
                     if (verifyResult.smtp && verifyResult.smtp.error && verifyResult.smtp.code) {
@@ -6060,6 +6070,7 @@ ${Buffer.from(data.content, 'base64url').toString('base64')}
         async handler(request) {
             try {
                 let verifyResult = await verifyAccountInfo(
+                    redis,
                     {
                         imap: {
                             host: request.payload.imap_host,
@@ -6777,7 +6788,8 @@ ${Buffer.from(data.content, 'base64url').toString('base64')}
                     availablePaths: JSON.stringify(mailboxes.map(entry => entry.path)),
 
                     hasIMAPPass: accountData.imap && accountData.imap.auth && !!accountData.imap.auth.pass,
-                    hasSMTPPass: accountData.smtp && accountData.smtp.auth && !!accountData.smtp.auth.pass
+                    hasSMTPPass: accountData.smtp && accountData.smtp.auth && !!accountData.smtp.auth.pass,
+                    defaultSmtpEhloName: await getServiceHostname()
                 },
                 {
                     layout: 'app'
@@ -6819,6 +6831,7 @@ ${Buffer.from(data.content, 'base64url').toString('base64')}
                     name: request.payload.name || '',
                     email: request.payload.email,
                     proxy: request.payload.proxy,
+                    smtpEhloName: request.payload.smtpEhloName,
                     path: request.payload.path || '*',
                     webhooks: request.payload.webhooks
                 };
@@ -6883,7 +6896,8 @@ ${Buffer.from(data.content, 'base64url').toString('base64')}
                         availablePaths: JSON.stringify(mailboxes.map(entry => entry.path)),
 
                         hasIMAPPass: accountData.imap && accountData.imap.auth && !!accountData.imap.auth.pass,
-                        hasSMTPPass: accountData.smtp && accountData.smtp.auth && !!accountData.smtp.auth.pass
+                        hasSMTPPass: accountData.smtp && accountData.smtp.auth && !!accountData.smtp.auth.pass,
+                        defaultSmtpEhloName: await getServiceHostname()
                     },
                     {
                         layout: 'app'
@@ -6928,7 +6942,8 @@ ${Buffer.from(data.content, 'base64url').toString('base64')}
                                 availablePaths: JSON.stringify(mailboxes.map(entry => entry.path)),
 
                                 hasIMAPPass: accountData.imap && accountData.imap.auth && !!accountData.imap.auth.pass,
-                                hasSMTPPass: accountData.smtp && accountData.smtp.auth && !!accountData.smtp.auth.pass
+                                hasSMTPPass: accountData.smtp && accountData.smtp.auth && !!accountData.smtp.auth.pass,
+                                defaultSmtpEhloName: await getServiceHostname()
                             },
                             {
                                 layout: 'app'
@@ -6946,6 +6961,7 @@ ${Buffer.from(data.content, 'base64url').toString('base64')}
                     email: Joi.string().email().required().example('user@example.com').label('Email').description('Your account email'),
 
                     proxy: settingsSchema.proxyUrl,
+                    smtpEhloName: settingsSchema.smtpEhloName,
 
                     imap: Joi.boolean().truthy('Y', 'true', '1', 'on').falsy('N', 'false', 0, '').default(false),
 
@@ -7653,6 +7669,7 @@ return payload;`
 
             let proxyEnabled = await settings.get('proxyEnabled');
             let proxyUrl = await settings.get('proxyUrl');
+            let smtpEhloName = await settings.get('smtpEhloName');
 
             let localAddresses = [].concat((await settings.get('localAddresses')) || []);
 
@@ -7670,11 +7687,13 @@ return payload;`
 
                     values: {
                         proxyEnabled,
-                        proxyUrl
+                        proxyUrl,
+                        smtpEhloName
                     },
 
                     addresses: await listPublicInterfaces(localAddresses),
-                    addressListTemplate: cachedTemplates.addressList
+                    addressListTemplate: cachedTemplates.addressList,
+                    defaultSmtpEhloName: await getServiceHostname()
                 },
                 {
                     layout: 'app'
@@ -7722,7 +7741,7 @@ return payload;`
         path: '/admin/config/network',
         async handler(request, h) {
             try {
-                for (let key of ['smtpStrategy', 'imapStrategy', 'localAddresses', 'proxyUrl', 'proxyEnabled']) {
+                for (let key of ['smtpStrategy', 'imapStrategy', 'localAddresses', 'proxyUrl', 'smtpEhloName', 'proxyEnabled']) {
                     await settings.set(key, request.payload[key]);
                 }
 
@@ -7745,7 +7764,8 @@ return payload;`
                         imapStrategies,
 
                         addresses: await listPublicInterfaces(request.payload.localAddresses),
-                        addressListTemplate: cachedTemplates.addressList
+                        addressListTemplate: cachedTemplates.addressList,
+                        defaultSmtpEhloName: await getServiceHostname()
                     },
                     {
                         layout: 'app'
@@ -7789,6 +7809,7 @@ return payload;`
 
                                 addresses: await listPublicInterfaces(request.payload.localAddresses),
                                 addressListTemplate: cachedTemplates.addressList,
+                                defaultSmtpEhloName: await getServiceHostname(),
 
                                 errors
                             },
@@ -7804,6 +7825,7 @@ return payload;`
                     localAddresses: settingsSchema.localAddresses.default([]),
 
                     proxyUrl: settingsSchema.proxyUrl,
+                    smtpEhloName: settingsSchema.smtpEhloName,
                     proxyEnabled: settingsSchema.proxyEnabled
                 })
             }

--- a/lib/schemas.js
+++ b/lib/schemas.js
@@ -117,6 +117,8 @@ const settingsSchema = {
         .description('Proxy URL')
         .label('ProxyURL'),
 
+    smtpEhloName: Joi.string().hostname().allow('', null).example('my.proxy.tld').description('Hostname to use for the SMTP EHLO/HELO greeting'),
+
     notifyText: Joi.boolean().truthy('Y', 'true', '1', 'on').falsy('N', 'false', 0, '').description('Include message text in webhook notification'),
     notifyWebSafeHtml: Joi.boolean()
         .truthy('Y', 'true', '1', 'on')

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -17,10 +17,12 @@ const Boom = require('@hapi/boom');
 const { ImapFlow } = require('imapflow');
 const nodemailer = require('nodemailer');
 const { parentPort } = require('worker_threads');
+const punycode = require('punycode/');
 const { PassThrough } = require('stream');
 const socks = require('socks');
 const os = require('os');
 const Fs = require('fs');
+const net = require('net');
 const fs = Fs.promises;
 const pathlib = require('path');
 const uuid = require('uuid');
@@ -708,11 +710,12 @@ MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEV3QUiYsp13nD9suD1/ZkEXnuMoSg
         }
     },
 
-    async verifyAccountInfo(accountData, logger) {
+    async verifyAccountInfo(redis, accountData, logger) {
         let response = {};
 
         let proxyUrl = await settings.get('proxyUrl');
         let proxyEnabled = await settings.get('proxyEnabled');
+        let smtpEhloName = await settings.get('smtpEhloName');
 
         if (accountData.imap) {
             try {
@@ -792,9 +795,13 @@ MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEV3QUiYsp13nD9suD1/ZkEXnuMoSg
 
         if (accountData.smtp) {
             try {
+                let { localAddress: address, name } = await module.exports.getLocalAddress(redis, 'smtp', 'test');
+
                 let smtpLogger = {};
                 let smtpConfig = Object.assign(
                     {
+                        name,
+                        localAddress: address,
                         transactionLog: true,
                         logger: smtpLogger
                     },
@@ -830,6 +837,10 @@ MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEV3QUiYsp13nD9suD1/ZkEXnuMoSg
                     smtpConfig.proxy = accountData.proxy;
                 } else if (proxyEnabled && proxyUrl && !smtpConfig.proxy) {
                     smtpConfig.proxy = proxyUrl;
+                }
+
+                if (accountData.smtpEhloName) {
+                    smtpConfig.name = accountData.smtpEhloName;
                 }
 
                 smtpConfig.forceAuth = true;
@@ -1298,6 +1309,72 @@ MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEV3QUiYsp13nD9suD1/ZkEXnuMoSg
                 resolve(Buffer.concat(chunks, chunklen));
             });
         });
+    },
+
+    async getServiceHostname(providedHostname) {
+        let hostname;
+        if (providedHostname) {
+            hostname = providedHostname;
+        } else {
+            let serviceUrl = (await settings.get('serviceUrl')) || null;
+            hostname = serviceUrl ? (new URL(serviceUrl).hostname || '').toString().toLowerCase().trim() : os.hostname();
+        }
+
+        if (hostname) {
+            try {
+                hostname = punycode.toASCII(hostname);
+            } catch (err) {
+                // ignore
+            }
+        }
+
+        return hostname;
+    },
+
+    async getLocalAddress(redis, protocol, account) {
+        let existingAddresses = Object.values(os.networkInterfaces())
+            .flatMap(entry => entry)
+            .map(entry => entry.address);
+
+        let addressStartegy = await settings.get(`${protocol}Strategy`);
+        let localAddresses = []
+            .concat((await settings.get(`localAddresses`)) || [])
+            .filter(address => existingAddresses.includes(address))
+            .filter(address => net.isIPv4(address));
+        let localAddress;
+
+        let hostname = await module.exports.getServiceHostname(await settings.get('smtpEhloName'));
+
+        if (!localAddresses.length) {
+            return { address: false, name: hostname };
+        } else if (localAddresses.length === 1) {
+            localAddress = localAddresses[0];
+        } else {
+            switch (addressStartegy) {
+                case 'random': {
+                    localAddress = localAddresses[Math.floor(Math.random() * localAddresses.length)];
+                    break;
+                }
+                case 'dedicated':
+                    localAddress = module.exports.selectRendezvousAddress(account, localAddresses);
+                    break;
+                default:
+                    return { address: false, name: hostname };
+            }
+        }
+
+        if (!localAddress) {
+            return { address: false, name: hostname };
+        }
+
+        try {
+            let addressData = JSON.parse(await redis.hget(`${REDIS_PREFIX}interfaces`, localAddress));
+            addressData.name = addressData.name || hostname;
+            return addressData;
+        } catch (err) {
+            logger.error({ msg: 'Failed to load address data', localAddress, err });
+            return { address: false, name: hostname };
+        }
     },
 
     unpackUIDRangeForSearch(uid) {

--- a/views/accounts/edit.hbs
+++ b/views/accounts/edit.hbs
@@ -252,6 +252,23 @@
             </div>
 
             <div class="form-group">
+
+                <div class="text-muted float-right code-link">[<a href="/admin/iframe/docs#/settings/postV1Settings"
+                        target="_blank">smtpEhloName</a>]</div>
+
+                <label for="smtpEhloName">SMTP Greeting Hostname</label>
+                <input type="text" class="form-control {{#if errors.proxyUrl}}is-invalid{{/if}}" id="smtpEhloName"
+                    placeholder="Proxy hostname like &quot;my.proxy.tld&quot;&mldr;" value="{{values.smtpEhloName}}"
+                    name="smtpEhloName">
+                {{#if errors.smtpEhloName}}
+                <span class="invalid-feedback">{{errors.smtpEhloName}}</span>
+                {{/if}}
+                <small id="smtpEhloNameBlock" class="form-text text-muted">Hostname to use for the SMTP EHLO/HELO
+                    greeting. Leave empty to use the default <code>{{defaultSmtpEhloName}}</code> or if you are using a
+                    dedicated IP address, then the name of the IP is preferred over this value.</small>
+            </div>
+
+            <div class="form-group">
                 <label for="webhooks">Webhook URL</label>
                 <input type="text" class="form-control {{#if errors.webhooks}}is-invalid{{/if}}" id="webhooks"
                     value="{{values.webhooks}}" placeholder="URL like &quot;https://myservice.com/imap/webhooks&quot;"

--- a/views/config/network.hbs
+++ b/views/config/network.hbs
@@ -47,8 +47,25 @@
                 {{#if errors.proxyUrl}}
                 <span class="invalid-feedback">{{errors.proxyUrl}}</span>
                 {{/if}}
-                <small id="passwordHelpBlock" class="form-text text-muted">Proxy URL must start with http://, https://,
+                <small id="proxyUrlBlock" class="form-text text-muted">Proxy URL must start with http://, https://,
                     socks://, socks4:// or socks5://</small>
+            </div>
+
+            <div class="form-group">
+
+                <div class="text-muted float-right code-link">[<a href="/admin/iframe/docs#/settings/postV1Settings"
+                        target="_blank">smtpEhloName</a>]</div>
+
+                <label for="smtpEhloName">SMTP Greeting Hostname</label>
+                <input type="text" class="form-control {{#if errors.proxyUrl}}is-invalid{{/if}}" id="smtpEhloName"
+                    placeholder="Proxy hostname like &quot;my.proxy.tld&quot;&mldr;" value="{{values.smtpEhloName}}"
+                    name="smtpEhloName">
+                {{#if errors.smtpEhloName}}
+                <span class="invalid-feedback">{{errors.smtpEhloName}}</span>
+                {{/if}}
+                <small id="smtpEhloNameBlock" class="form-text text-muted">Hostname to use for the SMTP EHLO/HELO
+                    greeting. Leave empty to use the default <code>{{defaultSmtpEhloName}}</code> or if you are using a
+                    dedicated IP address, then the name of the IP is preferred over this value.</small>
             </div>
         </div>
     </div>

--- a/workers/api.js
+++ b/workers/api.js
@@ -2008,6 +2008,7 @@ When making API calls remember that requests against the same account are queued
                     syncFrom: accountSchemas.syncFrom.default(null),
 
                     proxy: settingsSchema.proxyUrl,
+                    smtpEhloName: settingsSchema.smtpEhloName,
 
                     imap: Joi.object(imapSchema).allow(false).description('IMAP configuration').label('ImapConfiguration'),
 
@@ -2251,6 +2252,7 @@ When making API calls remember that requests against the same account are queued
                     syncFrom: accountSchemas.syncFrom,
 
                     proxy: settingsSchema.proxyUrl,
+                    smtpEhloName: settingsSchema.smtpEhloName,
 
                     imap: Joi.object(imapUpdateSchema).allow(false).description('IMAP configuration').label('IMAPUpdate'),
                     smtp: Joi.object(smtpUpdateSchema).allow(false).description('SMTP configuration').label('SMTPUpdate'),
@@ -2613,6 +2615,7 @@ When making API calls remember that requests against the same account are queued
                                     .example('https://myservice.com/imap/webhooks')
                                     .description('Account-specific webhook URL'),
                                 proxy: settingsSchema.proxyUrl,
+                                smtpEhloName: settingsSchema.smtpEhloName,
                                 syncTime: Joi.date().iso().example('2021-02-17T13:43:18.860Z').description('Last sync time'),
                                 lastError: lastErrorSchema.allow(null)
                             }).label('AccountResponseItem')
@@ -2666,6 +2669,7 @@ When making API calls remember that requests against the same account are queued
                     'subconnections',
                     'webhooks',
                     'proxy',
+                    'smtpEhloName',
                     'imap',
                     'smtp',
                     'oauth2',
@@ -2776,6 +2780,7 @@ When making API calls remember that requests against the same account are queued
                         .example('https://myservice.com/imap/webhooks')
                         .description('Account-specific webhook URL'),
                     proxy: settingsSchema.proxyUrl,
+                    smtpEhloName: settingsSchema.smtpEhloName,
 
                     imap: Joi.object(imapSchema).description('IMAP configuration').label('IMAPResponse'),
 
@@ -5097,7 +5102,7 @@ When making API calls remember that requests against the same account are queued
 
         async handler(request) {
             try {
-                return await verifyAccountInfo(request.payload, request.logger.child({ action: 'verify-account' }));
+                return await verifyAccountInfo(redis, request.payload, request.logger.child({ action: 'verify-account' }));
             } catch (err) {
                 request.logger.error({ msg: 'API request failed', err });
                 if (Boom.isBoom(err)) {
@@ -5135,7 +5140,8 @@ When making API calls remember that requests against the same account are queued
                     mailboxes: Joi.boolean().example(false).description('Include mailbox listing in response').default(false),
                     imap: Joi.object(imapSchema).allow(false).description('IMAP configuration').label('ImapConfiguration'),
                     smtp: Joi.object(smtpSchema).allow(false).description('SMTP configuration').label('SmtpConfiguration'),
-                    proxy: settingsSchema.proxyUrl
+                    proxy: settingsSchema.proxyUrl,
+                    smtpEhloName: settingsSchema.smtpEhloName
                 }).label('VerifyAccount')
             },
             response: {


### PR DESCRIPTION
Allow configuring EHLO hostname for SMTP greetings with setting option `smtpEhloName`