### PR TITLE
Webhook debug headers

### DIFF
--- a/lib/webhooks.js
+++ b/lib/webhooks.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const uuid = require('uuid');
 const { redis, notifyQueue } = require('./db');
 const msgpack = require('msgpack5')();
 const logger = require('./logger');
@@ -435,6 +436,7 @@ ${webhookData.content.map}
         // run all normalizations before sending the data
 
         const payload = pfStructuredClone(originalPayload);
+        payload.eventId = payload.eventId || uuid.v4();
 
         if (event === MESSAGE_NEW_NOTIFY && payload && payload.data && payload.data.text) {
             // normalize text content

--- a/workers/webhooks.js
+++ b/workers/webhooks.js
@@ -130,7 +130,6 @@ const notifyWorker = new Worker(
             customRoute = await Webhooks.getMeta(job.data._route.id);
             customMapping = job.data._route.mapping;
             delete job.data._route;
-
             if (!customRoute || !customRoute.enabled || !customRoute.targetUrl) {
                 return;
             }
@@ -274,7 +273,12 @@ const notifyWorker = new Worker(
         let start = Date.now();
         let duration;
 
-        let body = Buffer.from(JSON.stringify(customMapping || job.data));
+        let webhookPayload = customMapping || job.data;
+        if (webhookPayload.eventId) {
+            headers['X-EE-Wh-Event-Id'] = webhookPayload.eventId;
+            webhookPayload.eventId = undefined; // not included in JSON
+        }
+        let body = Buffer.from(JSON.stringify(webhookPayload));
 
         try {
             let res;

--- a/workers/webhooks.js
+++ b/workers/webhooks.js
@@ -236,7 +236,10 @@ const notifyWorker = new Worker(
 
         let headers = {
             'Content-Type': 'application/json',
-            'User-Agent': `${packageData.name}/${packageData.version} (+${packageData.homepage})`
+            'User-Agent': `${packageData.name}/${packageData.version} (+${packageData.homepage})`,
+            'X-EE-Wh-Id': (job.id || '').toString(),
+            'X-EE-Wh-Attempts-Made': (job.attemptsMade || 0).toString(),
+            'X-EE-Wh-Queued-Time': Math.round(Math.max(0, (Date.now() - job.timestamp) / 1000)) + 's'
         };
 
         let parsed = new URL(webhooks);
@@ -257,6 +260,7 @@ const notifyWorker = new Worker(
         }
 
         if (customRoute) {
+            headers['X-EE-Wh-Custom-Route'] = customRoute.id;
             for (let header of customRoute.customHeaders || []) {
                 headers[header.key] = header.value;
             }


### PR DESCRIPTION
Adds additional HTTP request headers for each webhook payload

| Header | Example value | Description |
|---|---|---|
| **X-EE-Wh-Event-Id** | `"af8435d9-ceee-4715-be71-08ac9d2dc04a"` | UUID assigned to the event. All webhook instances of the same event have the same event ID |
| **X-EE-Wh-Custom-Route** | `"AAABiL8tBKsAAAAG"` | Id of the custom webhook route used for this webhook |
| **X-EE-Wh-Queued-Time** | `"0s"` | How much time was this webhook queued |
| **X-EE-Wh-Attempts-Made** | `"1"` | The attempt counter for this webhook. Anything over 1 means that posting this webhook failed previously |
| **X-EE-Wh-Id** | `"907889"` | ID of the queued webhook entry |