### PR TITLE
Set outlook prompt authorization parameter

### DIFF
--- a/lib/oauth/outlook.js
+++ b/lib/oauth/outlook.js
@@ -92,6 +92,7 @@ class OutlookOauth {
         url.searchParams.set('redirect_uri', this.redirectUrl);
         url.searchParams.set('response_mode', 'query');
         url.searchParams.set('client_info', '1');
+        url.searchParams.set('prompt', 'select_account');
         url.searchParams.set('scope', this.scopes.join(' '));
 
         if (opts.state) {


### PR DESCRIPTION
For our usecase it is quite important that the user gets to pick which office account is used to authorize with Emailengine. Currently in some cases you are instantly logged in with your only active office account without being able to put in information for a different user during the login flow. This suggested change makes it so users are always shown a select account step during the office login flow. 

The impact for users who are already logged in with the account they actually want to use is minimal as they can instantly click their account in the list and continue the rest of the usual login flow without having to re-enter their password. But users who wish to login with a different account now get to click "Use another account" option in outlook.

Docs for this option are found here, specifically the `prompt` parameter: https://learn.microsoft.com/en-us/entra/identity-platform/v2-oauth2-auth-code-flow#request-an-authorization-code

