### PR TITLE
Added instruction on how to execute CLI commands while using the Docker Container.

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,21 @@ Read about running EmailEngine as a SystemD service [here](https://emailengine.a
 
 ![Docker Image Size (tag)](https://img.shields.io/docker/image-size/postalsys/emailengine/v2?label=Docker%20image%20size)
 
-See the documentation for using EmailEngine with Docker [here](https://emailengine.app/docker).
+To execute EmailEngine-CLI commands while using the Docker Container, you can use the following approach:
+
+1. Exec into the Docker Container:
+
+```
+$ docker exec -it <container-id> /bin/sh
+```
+
+2. Run the command by executing the `./bin/emailengine.js` file with node:
+
+```
+$ node bin/emailengine.js <command>
+```
+
+See the full documentation for using EmailEngine with Docker [here](https://emailengine.app/docker).
 
 ## Resolving issues with Redis
 


### PR DESCRIPTION
I was looking for a way to get a [prepared access token](https://emailengine.app/prepared-access-token) while using EmailEngine as a Docker Container without installing EmailEngine directly on my system. As this approach is not documented anywhere, I decided to give a step-by-step instruction on how to achieve this by executing `emailengine` commands without the CLI. 

If you are okay with the changes, you might want to consider adding this to your [Docker documentation](https://emailengine.app/docker) as well.