### PR TITLE
Add T-Online to providers needing an app password

### DIFF
--- a/lib/autodetect-imap-settings.js
+++ b/lib/autodetect-imap-settings.js
@@ -69,6 +69,18 @@ const APP_PASSWORDS = [
             instructions:
                 'https://support.microsoft.com/en-us/account-billing/using-app-passwords-with-apps-that-don-t-support-two-step-verification-5896ed9b-4263-e681-128a-a6f2979a7944'
         }
+    },
+
+    {
+        trigger: {
+            exchange: /\.t-online\.de$/i
+        },
+        value: {
+            required: true,
+            provider: 'T-Online',
+            instructions:
+                'https://www.telekom.de/hilfe/apps-dienste/e-mail/programme/passwort-definition'
+        }
     }
 ];
 


### PR DESCRIPTION
T-Online is a large german E-Mail provider which requires an App Password for Authentication.
I added it to the list so Instructions are shown in the Form.