### PR TITLE
Convert the contentType 'text' that graph api sends us into 'plain'

### DIFF
--- a/lib/email-client/outlook-client.js
+++ b/lib/email-client/outlook-client.js
@@ -1122,6 +1122,11 @@ class OutlookClient extends BaseClient {
             }
         }
 
+        // Microsoft Graph REST api 1.0 uses text and html, convert text to plain
+        if (messageData.body?.contentType === 'text') {
+            messageData.body.contentType = 'plain';
+        }
+
         if (messageData.parentFolderId) {
             let folder = await this.resolveFolder(messageData.parentFolderId, { byId: true });
             if (!folder) {


### PR DESCRIPTION
# Problem

the contentType returned by office 365 outlook client graph rest api is either `html` or `text`
However, emailengine expects it to be `html` or `plain`. This causes `plain` to be either empty or not set at all, even though the plain text exists. And a new property `text` to exist under `encodedSize`.
See: https://learn.microsoft.com/en-us/graph/api/resources/itembody?view=graph-rest-1.0

# Proposed solution

Add a check that corrects the contentType from `text` to `plain`.