### PR TITLE
fix: prevent IMAP proxy worker crashes and connection leaks

### DIFF
--- a/lib/imapproxy/imap-core/lib/imap-command.js
+++ b/lib/imapproxy/imap-core/lib/imap-command.js
@@ -369,7 +369,7 @@ class IMAPCommand {
     countBadResponses() {
         this.connection._badCount++;
         if (this.connection._badCount > MAX_BAD_COMMANDS) {
-            this.clearNotificationListener();
+            this.connection.clearNotificationListener();
             this.connection.send('* BYE Too many protocol errors');
             setImmediate(() => this.connection.close(true));
             return false;

--- a/lib/imapproxy/imap-core/lib/imap-connection.js
+++ b/lib/imapproxy/imap-core/lib/imap-connection.js
@@ -210,6 +210,13 @@ class IMAPConnection extends EventEmitter {
             this._socket.setTimeout(0, this._onTimeoutHandler);
         }
 
+        // After handoff to proxy mode the connection's own close/end handlers are gone,
+        // so _onClose can never run to remove this connection from the server set.
+        // Drop it from the set when the handed-off socket finally closes to avoid a leak.
+        this._socket.once('close', () => {
+            this._server.connections.delete(this);
+        });
+
         return { socket: this._socket };
     }
 

--- a/lib/imapproxy/imap-core/lib/imap-server.js
+++ b/lib/imapproxy/imap-core/lib/imap-server.js
@@ -258,7 +258,7 @@ class IMAPServer extends EventEmitter {
                                     },
                                     'PROXY from %s through %s (%s)',
                                     params[1].trim().toLowerCase(),
-                                    params[2].trim().toLowerCase(),
+                                    (params[2] || '').trim().toLowerCase(),
                                     JSON.stringify(params)
                                 );
                             }

--- a/lib/imapproxy/imap-server.js
+++ b/lib/imapproxy/imap-server.js
@@ -71,6 +71,30 @@ async function call(message, transferList) {
     });
 }
 
+// Resolve pending call() promises when the main thread answers. Without this any
+// RPC issued from this worker (via the `call` passed into Account) would never settle
+// and would reject on timeout. Mirrors the handlers in workers/imap.js and smtp.js.
+parentPort.on('message', message => {
+    if (message && message.cmd === 'resp' && message.mid && callQueue.has(message.mid)) {
+        let { resolve, reject, timer } = callQueue.get(message.mid);
+        clearTimeout(timer);
+        callQueue.delete(message.mid);
+
+        if (message.error) {
+            let err = new Error(message.error);
+            if (message.code) {
+                err.code = message.code;
+            }
+            if (message.statusCode) {
+                err.statusCode = message.statusCode;
+            }
+            return reject(err);
+        }
+
+        return resolve(message.response);
+    }
+});
+
 async function metrics(logger, key, method, ...args) {
     try {
         parentPort.postMessage({
@@ -86,7 +110,7 @@ async function metrics(logger, key, method, ...args) {
 
 const { ImapFlow } = require('imapflow');
 const { IMAPServer, imapHandler } = require('./imap-core/index.js');
-const { PassThrough } = require('./imap-core/lib/length-limiter.js');
+const { PassThrough } = require('stream');
 
 const packageInfo = require('../../package.json');
 const util = require('util');
@@ -113,7 +137,7 @@ class PassThroughLogger extends PassThrough {
                 data: chunk.toString('base64'),
                 compress: !!this.imapClient._deflate,
                 secure: !!this.imapClient.secureConnection,
-                cid: this.id
+                cid: this.cid
             });
         }
 
@@ -361,7 +385,7 @@ const createServer = function (options = {}) {
                 message = util.format(message, ...args);
             }
             data.msg = message;
-            if (typeof logger[level] === 'function') {
+            if (typeof serverLogger[level] === 'function') {
                 serverLogger[level](data);
             } else {
                 serverLogger.debug(data);
@@ -408,39 +432,78 @@ const createServer = function (options = {}) {
                                 logger: proxyLogger.child({ src: 'C' })
                             });
 
+                            // Idempotent teardown for both legs of the proxy. ImapFlow.close() is
+                            // safe after unbind(): it sends no LOGOUT, clears timers (including
+                            // autoidle), removes the deflate/writeSocket error forwarders and
+                            // destroys the upstream socket. Without it the upstream connection and
+                            // its idle timer would leak (most visibly with COMPRESS enabled).
+                            let proxyClosed = false;
+                            const closeProxy = () => {
+                                if (proxyClosed) {
+                                    return;
+                                }
+                                proxyClosed = true;
+
+                                try {
+                                    downstream.imapClient.close();
+                                } catch (err) {
+                                    proxyLogger.error({ msg: 'Failed to close upstream connection', err });
+                                }
+
+                                try {
+                                    if (upstream.socket && !upstream.socket.destroyed) {
+                                        upstream.socket.end();
+                                    }
+                                } catch (err) {
+                                    // ignore
+                                }
+                            };
+
+                            // Every terminal event from either leg funnels into the idempotent
+                            // closeProxy(). The helper keeps that wiring declarative; pass a message
+                            // to log (level defaults to 'error', use 'info' for graceful closes).
+                            const teardownOn = (emitter, event, msg, level = 'error') => {
+                                emitter.on(event, err => {
+                                    if (msg) {
+                                        let entry = { msg };
+                                        if (err) {
+                                            entry.err = err;
+                                        }
+                                        proxyLogger[level](entry);
+                                    }
+                                    closeProxy();
+                                });
+                            };
+
                             downstream.readSocket.pipe(upstreamLogger).pipe(upstream.socket);
                             upstream.socket.pipe(downstreamLogger).pipe(downstream.writeSocket);
 
-                            upstreamLogger.on('error', err => {
-                                proxyLogger.error({ msg: 'Client error', err });
-                                upstream.socket.end();
-                            });
-
-                            downstreamLogger.on('error', err => {
-                                proxyLogger.error({ msg: 'Server error', err });
-                                downstream.writeSocket.end();
-                                downstream.readSocket.end();
-                            });
+                            teardownOn(upstreamLogger, 'error', 'Proxy stream error (to client)');
+                            teardownOn(downstreamLogger, 'error', 'Proxy stream error (to upstream)');
+                            teardownOn(upstream.socket, 'error', 'Client socket error');
+                            teardownOn(upstream.socket, 'end', 'Client connection closed', 'info');
+                            teardownOn(upstream.socket, 'close');
+                            teardownOn(downstream.readSocket, 'end', 'Upstream connection closed', 'info');
 
                             downstream.readSocket.on('error', err => {
-                                proxyLogger.error({ msg: 'Client error', err });
-                                upstreamLogger.end('* BYE Upstream connection error\r\n');
+                                proxyLogger.error({ msg: 'Upstream read error', err });
+                                try {
+                                    // best-effort notice to the client before tearing down
+                                    upstream.socket.write('* BYE Upstream connection error\r\n');
+                                } catch (e) {
+                                    // ignore
+                                }
+                                closeProxy();
                             });
 
-                            upstream.socket.on('error', err => {
-                                proxyLogger.error({ msg: 'Upstream error', err });
-                                downstreamLogger.end();
-                            });
-
-                            downstream.readSocket.on('end', () => {
-                                proxyLogger.info({ msg: 'Client connection closed' });
-                                upstreamLogger.end();
-                            });
-
-                            upstream.socket.on('end', () => {
-                                proxyLogger.info({ msg: 'Server connection closed' });
-                                downstreamLogger.end();
-                            });
+                            // With COMPRESS enabled, readSocket/writeSocket are the inflate/deflate
+                            // streams, not the raw upstream socket, and unbind() removed ImapFlow's
+                            // own listeners from that socket. An upstream reset would then emit an
+                            // 'error' with no listener and crash the worker - guard it explicitly.
+                            if (downstream.imapClient.socket && downstream.imapClient.socket !== downstream.readSocket) {
+                                teardownOn(downstream.imapClient.socket, 'error', 'Upstream socket error');
+                                teardownOn(downstream.imapClient.socket, 'close');
+                            }
 
                             proxyLogger.info({ msg: 'Proxy mode enabled' });
                         };

--- a/test/imap-proxy-protocol-test.js
+++ b/test/imap-proxy-protocol-test.js
@@ -1,0 +1,193 @@
+'use strict';
+
+// Regression tests for the IMAP proxy protocol layer (lib/imapproxy/imap-core).
+//
+// These drive the imap-core IMAPServer directly (no Redis/Account/worker needed) and
+// connect with a raw TCP socket, mirroring the production proxy configuration
+// ({ secure: false, disableSTARTTLS: true, proxyMode: true }).
+//
+// Covered:
+//  - F1: a client sending more than MAX_BAD_COMMANDS bad commands must receive
+//        "* BYE Too many protocol errors" and disconnect, NOT crash the worker.
+//        (Before the fix, countBadResponses() called a method that does not exist on
+//         IMAPCommand, throwing a TypeError that reached the global handler.)
+//  - F2: a connection that enters proxy mode must be removed from server.connections
+//        once its handed-off socket closes (before the fix it leaked forever, because
+//        unbind() strips the close/end/error listeners so _onClose never runs).
+
+const test = require('node:test');
+const assert = require('node:assert');
+const net = require('node:net');
+
+const { IMAPServer } = require('../lib/imapproxy/imap-core/index.js');
+
+// silent logger for the server
+const silentLogger = false;
+
+function startServer(onAuth) {
+    return new Promise((resolve, reject) => {
+        const server = new IMAPServer({
+            secure: false,
+            disableSTARTTLS: true,
+            proxyMode: true,
+            logger: silentLogger,
+            id: { name: 'EmailEngine IMAP Proxy Test' }
+        });
+
+        if (typeof onAuth === 'function') {
+            server.onAuth = onAuth;
+        }
+
+        server.on('error', reject);
+        server.listen(0, '127.0.0.1', () => {
+            resolve({ server, port: server.server.address().port });
+        });
+    });
+}
+
+function closeServer(server) {
+    return new Promise(resolve => {
+        server.close(() => resolve());
+    });
+}
+
+// Connect, wait for the greeting, send the supplied lines, then resolve with the full
+// response text once the socket closes (or once `untilMarker` is observed).
+function runRawClient({ port, lines, untilMarker, idleTimeout = 4000 }) {
+    return new Promise((resolve, reject) => {
+        const socket = net.connect({ port, host: '127.0.0.1' });
+        let buffer = '';
+        let greeted = false;
+        let settled = false;
+
+        const finish = () => {
+            if (settled) {
+                return;
+            }
+            settled = true;
+            clearTimeout(timer);
+            try {
+                socket.destroy();
+            } catch (err) {
+                // ignore
+            }
+            resolve(buffer);
+        };
+
+        const timer = setTimeout(finish, idleTimeout);
+
+        socket.setEncoding('utf8');
+        socket.on('data', chunk => {
+            buffer += chunk;
+            if (!greeted && /\* OK /.test(buffer)) {
+                greeted = true;
+                for (let line of lines) {
+                    socket.write(line + '\r\n');
+                }
+            }
+            if (untilMarker && buffer.includes(untilMarker)) {
+                finish();
+            }
+        });
+
+        socket.on('close', finish);
+        socket.on('error', err => {
+            if (settled) {
+                return;
+            }
+            settled = true;
+            clearTimeout(timer);
+            reject(err);
+        });
+    });
+}
+
+test('F1: too many bad commands yields BYE and does not crash the worker', async () => {
+    const { server, port } = await startServer();
+
+    try {
+        // MAX_BAD_COMMANDS is 50; send well past it.
+        const lines = [];
+        for (let i = 1; i <= 60; i++) {
+            lines.push(`A${i} ZZZBOGUS`);
+        }
+
+        const resp = await runRawClient({
+            port,
+            lines,
+            untilMarker: 'Too many protocol errors'
+        });
+
+        assert.match(resp, /\* BYE Too many protocol errors/, 'server should send the protocol-error BYE');
+        // If the bug were present the process would have crashed with a TypeError
+        // before reaching this assertion.
+    } finally {
+        await closeServer(server);
+    }
+});
+
+test('F2: proxied connection is removed from server.connections after its socket closes', async () => {
+    const { server, port } = await startServer((login, session, callback) => {
+        // mirror the production wiring: onProxy is set before auth completes
+        session.onProxy = () => {
+            // stub: hold the handed-off socket, do nothing with it
+        };
+        callback(null, {
+            user: {
+                id: 'id.' + login.username,
+                username: login.username
+            }
+        });
+    });
+
+    try {
+        const socket = net.connect({ port, host: '127.0.0.1' });
+        socket.setEncoding('utf8');
+
+        let buffer = '';
+        let sentLogin = false;
+        await new Promise((resolve, reject) => {
+            const timer = setTimeout(() => reject(new Error('timed out waiting for login OK')), 4000);
+            socket.on('error', reject);
+            socket.on('data', chunk => {
+                buffer += chunk;
+                if (!sentLogin && /\* OK /.test(buffer)) {
+                    sentLogin = true;
+                    socket.write('A1 LOGIN testuser testpass\r\n');
+                }
+                if (/^A1 OK/m.test(buffer)) {
+                    clearTimeout(timer);
+                    resolve();
+                }
+            });
+        });
+
+        // connection is now in proxy mode and must still be tracked
+        assert.strictEqual(server.connections.size, 1, 'connection should be tracked while proxying');
+
+        // client disconnects -> handed-off socket closes -> connection must be dropped
+        await new Promise(resolve => {
+            socket.on('close', resolve);
+            socket.end();
+        });
+
+        // wait for the server-side 'close' to propagate
+        await new Promise((resolve, reject) => {
+            const deadline = Date.now() + 4000;
+            const poll = () => {
+                if (server.connections.size === 0) {
+                    return resolve();
+                }
+                if (Date.now() > deadline) {
+                    return reject(new Error(`connection leaked: server.connections.size=${server.connections.size}`));
+                }
+                setTimeout(poll, 25);
+            };
+            poll();
+        });
+
+        assert.strictEqual(server.connections.size, 0, 'proxied connection must be removed after close');
+    } finally {
+        await closeServer(server);
+    }
+});


### PR DESCRIPTION
## Summary

Fixes several issues in the IMAP proxy that could crash a proxy worker (taking down every account on that worker) or leak resources over long uptime. Each finding was verified by reading the code paths and the maintained ImapFlow source before fixing.

### Critical
- **Worker crash (DoS) after 50 bad commands** - `countBadResponses()` called `this.clearNotificationListener()`, a method that only exists on `IMAPConnection`, not `IMAPCommand`. Any client sending >50 bad commands threw a `TypeError` that reached the global handler and killed the worker. Now calls it on the connection.
- **Connection/memory leak** - proxied connections were never removed from `server.connections` because `unbind()` strips the socket's close/end/error listeners so `_onClose` can never run. `unbind()` now drops the connection from the set when the handed-off socket closes.
- **Upstream crash + connection/timer leak with COMPRESS** - with compression active (the default for most providers), after `unbind()` the raw upstream socket has no error listener, so an upstream reset crashed the worker and the upstream connection plus ImapFlow's idle timer leaked. `onProxy` now tears down through a single idempotent `closeProxy()` that calls `imapClient.close()`, and guards the raw upstream socket's error/close events.

### Latent / minor
- Added the missing `cmd:'resp'` `parentPort` handler so `call()` RPC from the proxy worker actually resolves (mirrors `workers/imap.js` and `workers/smtp.js`).
- Fixed undefined `cid` in raw trace logs, a fragile `PassThrough` import, the server log-level guard checking the wrong object, and an unguarded PROXY-protocol header parse.

## Tests

Adds `test/imap-proxy-protocol-test.js` (native `node:test`) covering the bad-command BYE path and the proxied-connection cleanup. Full CI suite (lint + tests) passes.

## Follow-up (out of scope)

Consider hardening ImapFlow's `unbind()` contract so the raw socket isn't left without an error listener after handoff - defense-in-depth for the compression crash class, in the maintained `../imapflow` repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
