### PR TITLE
ci: add timeout guard to tagged Docker build job

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -63,6 +63,10 @@ jobs:
         runs-on: ubuntu-latest
         needs: release_please
         if: ${{needs.release_please.outputs.release_created}}
+        # Multi-arch builds run the arm64 leg under QEMU emulation, which can
+        # hang indefinitely on a misbehaving step. A normal build finishes in
+        # ~4 minutes, so fail fast instead of burning the 6-hour default limit.
+        timeout-minutes: 30
         steps:
             - run: echo version v${{needs.release_please.outputs.major}}.${{needs.release_please.outputs.minor}}.${{needs.release_please.outputs.patch}}
 


### PR DESCRIPTION
## Problem

The 2.68.1 release Docker build (`publish_docker` job in `release.yaml`) hung for over an hour and had to be cancelled, leaving no tagged image on Docker Hub or GHCR. Normal multi-arch builds finish in ~3.5 minutes.

The job builds `linux/amd64,linux/arm64/v8`, running the arm64 leg under QEMU emulation. A misbehaving step under emulation can hang indefinitely, and the job had no `timeout-minutes`, so it would run until GitHub's 6-hour hard limit.

## Change

Add `timeout-minutes: 30` to the `publish_docker` job so a stuck emulation fails fast and surfaces clearly instead of silently wedging the release.

## Notes

- The Dockerfile, `update-info.sh`, `prepare-docker.js`, and `release.yaml` build steps were **not** changed by the recent security hardening - verified via `git diff bcb2ba30..HEAD`. This is a build-hang mitigation, not a fix for a Dockerfile regression.
- Root cause of the hang (likely a dependency stalling under QEMU among the 2.68.1 dep bumps) is still under investigation - this guard just bounds the blast radius.

🤖 Generated with [Claude Code](https://claude.com/claude-code)