### PR TITLE
fix: harden inter-thread IPC (worker-death call rejection, webhook guards, stream cleanup)

### DIFF
--- a/lib/account.js
+++ b/lib/account.js
@@ -1090,16 +1090,25 @@ class Account {
         const { port1, port2 } = new MessageChannel();
         const stream = new MessagePortReadable(port1);
 
-        let streamCreated = await this.call(
-            {
-                cmd: 'getRawMessage',
-                account: this.account,
-                message,
-                timeout: this.timeout,
-                port: port2
-            },
-            [port2]
-        );
+        let streamCreated;
+        try {
+            streamCreated = await this.call(
+                {
+                    cmd: 'getRawMessage',
+                    account: this.account,
+                    message,
+                    timeout: this.timeout,
+                    port: port2
+                },
+                [port2]
+            );
+        } catch (err) {
+            // The setup call failed (timeout, worker gone, 404). Destroy the reader so
+            // its MessagePort + listener are released instead of leaking, and so any
+            // late producer data is not buffered forever.
+            stream.destroy();
+            throw err;
+        }
 
         if (streamCreated && streamCreated.headers) {
             stream.headers = streamCreated.headers;
@@ -1114,16 +1123,25 @@ class Account {
         const { port1, port2 } = new MessageChannel();
         const stream = new MessagePortReadable(port1);
 
-        let streamCreated = await this.call(
-            {
-                cmd: 'getAttachment',
-                account: this.account,
-                attachment,
-                timeout: this.timeout,
-                port: port2
-            },
-            [port2]
-        );
+        let streamCreated;
+        try {
+            streamCreated = await this.call(
+                {
+                    cmd: 'getAttachment',
+                    account: this.account,
+                    attachment,
+                    timeout: this.timeout,
+                    port: port2
+                },
+                [port2]
+            );
+        } catch (err) {
+            // The setup call failed (timeout, worker gone, 404). Destroy the reader so
+            // its MessagePort + listener are released instead of leaking, and so any
+            // late producer data is not buffered forever.
+            stream.destroy();
+            throw err;
+        }
 
         if (streamCreated && streamCreated.headers) {
             stream.headers = streamCreated.headers;
@@ -1547,14 +1565,20 @@ class Account {
 
                 // download large inline attachments not stored in ES
                 for (let attachment of attachmentsToDownload) {
+                    let downloadStream;
                     try {
-                        let downloadStream = await this.getAttachment(attachment.id);
+                        downloadStream = await this.getAttachment(attachment.id);
                         if (downloadStream) {
                             let content = await download(downloadStream);
                             this.logger.trace({ msg: 'Fetched attachment content', account: this.account, attachment, size: content.length });
                             attachment.content = content.toString('base64');
                         }
                     } catch (err) {
+                        // Release the reader if download() failed mid-stream so its
+                        // MessagePort is not left open (destroy() is idempotent).
+                        if (downloadStream) {
+                            downloadStream.destroy();
+                        }
                         this.logger.error({ msg: 'Failed to fetch attachment content', account: this.account, attachment, err });
                     }
                 }

--- a/lib/reject-worker-calls.js
+++ b/lib/reject-worker-calls.js
@@ -1,0 +1,42 @@
+'use strict';
+
+/**
+ * Reject every pending cross-thread call routed to a worker thread that has
+ * terminated. Without this, a call placed against a worker that then crashes or
+ * is force-restarted keeps waiting until its own timeout fires - which can be
+ * minutes (the submitMessage floor) or hours (a large X-EE-Timeout). Rejecting
+ * here lets the caller fail fast with a retryable error the instant the worker
+ * is known to be gone.
+ *
+ * The stored `reject` wrapper clears the entry's timeout, so we only need to
+ * drop the entry from the queue and invoke it.
+ *
+ * @param {Map} callQueue - mid -> { resolve, reject, timer, worker }
+ * @param {Worker} worker - The terminated worker thread
+ * @param {Error} err - Rejection reason. May be a shared instance reused across
+ *   concurrent rejections, so callers must not attach per-call fields to it.
+ * @returns {number} Number of pending calls that were rejected
+ */
+function rejectWorkerCalls(callQueue, worker, err) {
+    let rejected = 0;
+
+    // Deleting the current entry while iterating a Map is safe in JS.
+    for (let [mid, entry] of callQueue) {
+        if (entry.worker !== worker) {
+            continue;
+        }
+
+        callQueue.delete(mid);
+        try {
+            entry.reject(err);
+        } catch (rejectErr) {
+            // A consumer that throws synchronously from its rejection path must
+            // not stop us from cleaning up the remaining pending calls.
+        }
+        rejected++;
+    }
+
+    return rejected;
+}
+
+module.exports = { rejectWorkerCalls };

--- a/server.js
+++ b/server.js
@@ -148,6 +148,8 @@ const { QueueEvents } = require('bullmq');
 
 const getSecret = require('./lib/get-secret');
 
+const { rejectWorkerCalls } = require('./lib/reject-worker-calls');
+
 const msgpack = require('msgpack5')();
 
 // Initialize default configuration values if not set
@@ -274,6 +276,12 @@ logger.info({
 const NO_ACTIVE_HANDLER_RESP_ERR = new Error('No active handler for requested account. Try again later.');
 NO_ACTIVE_HANDLER_RESP_ERR.statusCode = 503;
 NO_ACTIVE_HANDLER_RESP_ERR.code = 'WorkerNotAvailable';
+
+// Shared rejection for in-flight calls whose target worker terminated mid-request.
+// Reused across concurrent rejections - never attach per-call fields to this instance.
+const WORKER_DIED_RESP_ERR = new Error('Worker handling the request terminated before completion. Try again.');
+WORKER_DIED_RESP_ERR.statusCode = 503;
+WORKER_DIED_RESP_ERR.code = 'WorkerNotAvailable';
 
 // Update check intervals
 const UPGRADE_CHECK_TIMEOUT = 1 * 24 * 3600 * 1000; // 24 hours
@@ -1013,6 +1021,13 @@ let spawnWorker = async type => {
             onlineWorkers.delete(worker);
             metrics.threadStops.inc();
 
+            // Fail any in-flight calls routed to this worker right away, so callers
+            // get a fast retryable error instead of hanging until their own timeout.
+            let rejectedCalls = rejectWorkerCalls(callQueue, worker, WORKER_DIED_RESP_ERR);
+            if (rejectedCalls) {
+                logger.info({ msg: 'Rejected in-flight calls for exited worker', type, threadId: worker.threadId, rejectedCalls });
+            }
+
             workers.get(type).delete(worker);
 
             // Update server state for proxy servers
@@ -1499,7 +1514,8 @@ async function call(worker, message, transferList) {
             reject(err);
         }, ttl);
 
-        // Store callback info
+        // Store callback info. `worker` lets us reject this entry immediately if
+        // the target worker terminates, instead of waiting out the timeout.
         callQueue.set(mid, {
             resolve: result => {
                 clearTimeout(timer);
@@ -1509,7 +1525,8 @@ async function call(worker, message, transferList) {
                 clearTimeout(timer);
                 reject(err);
             },
-            timer
+            timer,
+            worker
         });
 
         try {

--- a/test/message-port-stream-test.js
+++ b/test/message-port-stream-test.js
@@ -112,6 +112,35 @@ test('a producer error reaches the reader as a stream error, not a clean end (Co
     }
 });
 
+test('destroying a reader whose producer never attached releases the port (setup-failure cleanup)', async () => {
+    // Mirrors lib/account.js: a getRawMessage/getAttachment setup call rejects (timeout,
+    // worker gone, 404) before the IMAP worker attaches a writable to the transferred
+    // port. The consumer destroys the reader; this must release port1's listener and tell
+    // the (possibly future) producer to stop via { cancel: true }.
+    const { port1, port2 } = new MessageChannel();
+
+    try {
+        const reader = new MessagePortReadable(port1);
+
+        const peerMessages = [];
+        port2.on('message', message => peerMessages.push(message));
+
+        assert.strictEqual(port1.listenerCount('message'), 1, 'reader should hold a port listener before cleanup');
+
+        reader.destroy();
+        await tick();
+
+        assert.strictEqual(port1.listenerCount('message'), 0, 'reader message listener must be removed on destroy');
+        assert.ok(
+            peerMessages.some(message => message && message.cancel),
+            'the producer side must receive a cancel signal'
+        );
+    } finally {
+        port1.close();
+        port2.close();
+    }
+});
+
 test('normal completion closes the reader port and removes its listener (Commit 3)', async () => {
     const { port1, port2 } = new MessageChannel();
 

--- a/test/reject-worker-calls-test.js
+++ b/test/reject-worker-calls-test.js
@@ -1,0 +1,97 @@
+'use strict';
+
+// Regression tests for lib/reject-worker-calls.js. When a worker thread terminates,
+// the main thread must reject the pending cross-thread calls routed to it instead of
+// leaving them to hang until their individual timeouts fire.
+
+const test = require('node:test');
+const assert = require('node:assert').strict;
+
+const { rejectWorkerCalls } = require('../lib/reject-worker-calls');
+
+// Build a callQueue entry shaped like the ones server.js stores.
+function makeEntry(worker) {
+    const entry = {
+        worker,
+        rejectedWith: undefined,
+        timerCleared: false
+    };
+    entry.timer = setTimeout(() => {}, 60 * 1000);
+    entry.reject = err => {
+        clearTimeout(entry.timer);
+        entry.timerCleared = true;
+        entry.rejectedWith = err;
+    };
+    return entry;
+}
+
+test('rejectWorkerCalls() rejects only the dead worker entries and removes them', () => {
+    const workerA = { threadId: 1 };
+    const workerB = { threadId: 2 };
+
+    const callQueue = new Map();
+    callQueue.set('a1', makeEntry(workerA));
+    callQueue.set('a2', makeEntry(workerA));
+    callQueue.set('b1', makeEntry(workerB));
+
+    const err = new Error('Worker terminated');
+
+    const rejected = rejectWorkerCalls(callQueue, workerA, err);
+
+    assert.strictEqual(rejected, 2, 'should report both workerA calls rejected');
+    assert.strictEqual(callQueue.size, 1, 'only the surviving workerB call should remain');
+    assert.ok(callQueue.has('b1'), 'workerB call must be untouched');
+
+    const survivor = callQueue.get('b1');
+    assert.strictEqual(survivor.rejectedWith, undefined, 'workerB call must not be rejected');
+    clearTimeout(survivor.timer);
+});
+
+test('rejectWorkerCalls() forwards the shared error and clears timers', () => {
+    const worker = { threadId: 7 };
+    const entry = makeEntry(worker);
+
+    const callQueue = new Map([['mid', entry]]);
+    const err = new Error('Worker terminated');
+
+    rejectWorkerCalls(callQueue, worker, err);
+
+    assert.strictEqual(entry.rejectedWith, err, 'entry should be rejected with the provided error');
+    assert.strictEqual(entry.timerCleared, true, 'the entry timeout should be cleared on rejection');
+});
+
+test('rejectWorkerCalls() keeps cleaning up after a rejection callback throws', () => {
+    const worker = { threadId: 9 };
+
+    const throwing = makeEntry(worker);
+    throwing.reject = () => {
+        clearTimeout(throwing.timer);
+        throw new Error('synchronous failure in rejection handler');
+    };
+    const healthy = makeEntry(worker);
+
+    const callQueue = new Map([
+        ['bad', throwing],
+        ['good', healthy]
+    ]);
+
+    const rejected = rejectWorkerCalls(callQueue, worker, new Error('Worker terminated'));
+
+    assert.strictEqual(rejected, 2, 'both entries should be counted even when one throws');
+    assert.strictEqual(callQueue.size, 0, 'all matching entries should be removed');
+    assert.ok(healthy.rejectedWith, 'the second entry must still be rejected');
+});
+
+test('rejectWorkerCalls() returns 0 when no entries match', () => {
+    const worker = { threadId: 1 };
+    const other = { threadId: 2 };
+
+    const entry = makeEntry(other);
+    const callQueue = new Map([['mid', entry]]);
+
+    const rejected = rejectWorkerCalls(callQueue, worker, new Error('Worker terminated'));
+
+    assert.strictEqual(rejected, 0, 'no calls should be rejected');
+    assert.strictEqual(callQueue.size, 1, 'the unrelated entry should remain');
+    clearTimeout(entry.timer);
+});

--- a/workers/export.js
+++ b/workers/export.js
@@ -810,14 +810,19 @@ const exportWorker = new Worker(
             }
 
             if (err.code !== 'AccountDeleted' && err.code !== 'AccountNotFound' && err.code !== 'ExportCancelled') {
-                await notify(account, EXPORT_FAILED_NOTIFY, {
-                    exportId,
-                    error: err.message,
-                    errorCode: err.code,
-                    phase: exportData.phase || 'unknown',
-                    messagesExported: Number(exportData.messagesExported) || 0,
-                    messagesQueued: Number(exportData.messagesQueued) || 0
-                });
+                try {
+                    await notify(account, EXPORT_FAILED_NOTIFY, {
+                        exportId,
+                        error: err.message,
+                        errorCode: err.code,
+                        phase: exportData.phase || 'unknown',
+                        messagesExported: Number(exportData.messagesExported) || 0,
+                        messagesQueued: Number(exportData.messagesQueued) || 0
+                    });
+                } catch (notifyErr) {
+                    // Never let a failed notification replace the original error below.
+                    logger.error({ msg: 'Failed to deliver export failure notification', account, exportId, err: notifyErr });
+                }
             }
 
             throw err;

--- a/workers/submit.js
+++ b/workers/submit.js
@@ -409,12 +409,24 @@ submitWorker.on('failed', async job => {
                 logger.error({ msg: 'Failed to remove queue entry', account: job.data.account, queueId: job.data.queueId, messageId: job.data.messageId, err });
             }
             // report as failed
-            await notify(job.data.account, EMAIL_FAILED_NOTIFY, {
-                messageId: job.data.messageId,
-                queueId: job.data.queueId,
-                error: job.stacktrace && job.stacktrace[0] && job.stacktrace[0].split('\n').shift(),
-                networkRouting: job.progress?.networkRouting
-            });
+            try {
+                await notify(job.data.account, EMAIL_FAILED_NOTIFY, {
+                    messageId: job.data.messageId,
+                    queueId: job.data.queueId,
+                    error: job.stacktrace && job.stacktrace[0] && job.stacktrace[0].split('\n').shift(),
+                    networkRouting: job.progress?.networkRouting
+                });
+            } catch (notifyErr) {
+                // A failed webhook notification must not bubble out of this BullMQ
+                // event listener as an unhandled rejection and take down the worker.
+                logger.error({
+                    msg: 'Failed to deliver submission failure notification',
+                    account: job.data.account,
+                    queueId: job.data.queueId,
+                    messageId: job.data.messageId,
+                    err: notifyErr
+                });
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

An IPC audit of EmailEngine's worker-thread communication surfaced three robustness defects that matter for critical-infra deployments. Each is a self-contained `fix:` commit.

1. **Reject in-flight worker calls when a worker thread terminates** (`server.js`, new `lib/reject-worker-calls.js`)
   When a worker crashed or was force-restarted by the health check, its accounts were reassigned but the main thread's in-flight RPC calls routed to it kept waiting until their own timeout fired - up to the 10-minute `submitMessage` floor or a 2-hour `X-EE-Timeout`. The HTTP request and a dangling `callQueue` entry hung for that whole window. Each `callQueue` entry is now tagged with its target worker, and the single `exitHandler` chokepoint rejects every pending call for the dead worker with a retryable `503 WorkerNotAvailable`. Affected `submitMessage` jobs retry on a live worker (503 is already treated as transient) instead of hanging.

2. **Guard webhook notifications in BullMQ failure handlers** (`workers/submit.js`, `workers/export.js`)
   The submit worker's `on('failed')` listener awaited `notify()` (a webhook delivery that hits Redis/BullMQ) with no try/catch. Because BullMQ emits `failed` via a synchronous `super.emit`, a rejection there became a global unhandled rejection and took the whole submit worker down on a transient Redis blip. The same guard is applied to the export worker's failure-path `notify()`, where an unguarded rejection previously masked the original error before the `throw err` re-raise (the throw stays outside the try).

3. **Release MessagePort streams when message/attachment downloads fail** (`lib/account.js`)
   `getRawMessage`/`getAttachment` created a `MessageChannel` + `MessagePortReadable`, transferred the write port to the IMAP worker, then awaited the setup call. If that call rejected (timeout against a slow account, worker gone, or a 404), the reader was never returned and never destroyed: its MessagePort kept an active listener (a leaked, un-GC'able port) and any late producer data buffered forever. The reader is now destroyed on the failure path, and likewise in the inline-attachment loop when `download()` fails mid-stream (`destroy()` is idempotent).

## Testing

- New `test/reject-worker-calls-test.js` (4 cases) and an extended `test/message-port-stream-test.js` (setup-failure cleanup contract).
- Full suite: `npm test` -> 926 pass, 0 fail. Lint clean.
- `/simplify` (clean) and `/security-review` (no vulnerabilities; change is fail-closed) both run.

## Reviewer note

This changes `getThreadsInfo`'s `unresponsive` flag for a *dead* worker (now `false`/503 instead of `true`/504 - more accurate, since dead != hung). Harmless unless something alerts on that field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
