### PR TITLE
refactor: begin routes-ui.js extraction into ui-routes/ modules (A2)

### DIFF
--- a/lib/routes-ui.js
+++ b/lib/routes-ui.js
@@ -35,7 +35,6 @@ const pbkdf2 = require('@phc/pbkdf2');
 const { Account } = require('./account');
 const { Gateway } = require('./gateway');
 const { redis, submitQueue, notifyQueue, documentsQueue } = require('./db');
-const psl = require('psl');
 const { oauth2Apps, OAUTH_PROVIDERS, oauth2ProviderData, SERVICE_ACCOUNT_PROVIDERS } = require('./oauth2-apps');
 const { verifyOAuth2App } = require('./oauth/verify-app');
 const { autodetectImapSettings } = require('./autodetect-imap-settings');
@@ -51,13 +50,11 @@ const {
     exportIdSchema
 } = require('./schemas');
 const fs = require('fs');
-const pathlib = require('path');
 const timezonesList = require('timezones-list').default;
 const { Client: ElasticSearch } = require('@elastic/elasticsearch');
 const { llmPreProcess } = require('./llm-pre-process');
 const { locales } = require('./translations');
 const capa = require('./capa');
-const exampleDocumentsPayloads = require('./payload-examples-documents.json');
 const { defaultMappings } = require('./es');
 const { getESClient } = require('../lib/document-store');
 const assert = require('assert');
@@ -68,6 +65,17 @@ const { simpleParser } = require('mailparser');
 const libmime = require('libmime');
 
 const adminEntitiesRoutes = require('./ui-routes/admin-entities-routes');
+const smtpTestRoutes = require('./ui-routes/smtp-test-routes');
+const unsubscribeRoutes = require('./ui-routes/unsubscribe-routes');
+const {
+    throwAsBoom,
+    formatAccountData,
+    getServerStatus,
+    getOpenAiModels,
+    OPEN_AI_MODELS,
+    getExampleDocumentsPayloads,
+    cachedTemplates
+} = require('./ui-routes/route-helpers');
 const { Export } = require('./export');
 const passkeys = require('./passkeys');
 const {
@@ -115,24 +123,6 @@ const DISABLE_MESSAGE_BROWSER = getBoolean(readEnvValue('EENGINE_DISABLE_MESSAGE
 const { fetch: fetchCmd } = require('undici');
 
 const LICENSE_HOST = 'https://postalsys.com';
-const SMTP_TEST_HOST = 'https://api.nodemailer.com';
-
-const OPEN_AI_MODELS = [
-    {
-        name: 'GPT-3 (instruct)',
-        id: 'gpt-3.5-turbo-instruct'
-    },
-
-    {
-        name: 'GPT-3 (chat)',
-        id: 'gpt-3.5-turbo'
-    },
-
-    {
-        name: 'GPT-4',
-        id: 'gpt-4'
-    }
-];
 
 const IMAP_INDEXERS = [
     {
@@ -184,27 +174,6 @@ const notificationTypes = Object.keys(consts)
         name: consts[`${key}_NOTIFY`],
         description: consts[`${key}_DESCRIPTION`]
     }));
-
-const cachedTemplates = {
-    addressList: fs.readFileSync(pathlib.join(__dirname, '..', 'views', 'partials', 'address_list.hbs'), 'utf-8'),
-    testSend: fs.readFileSync(pathlib.join(__dirname, '..', 'views', 'partials', 'test_send.hbs'), 'utf-8')
-};
-
-const getOpenAiModels = async (models, selectedModel) => {
-    let modelList = (await settings.get('openAiModels')) || structuredClone(models);
-
-    if (selectedModel && !modelList.find(model => model.id === selectedModel)) {
-        modelList.unshift({
-            name: selectedModel,
-            id: selectedModel
-        });
-    }
-
-    return modelList.map(model => {
-        model.selected = model.id === selectedModel;
-        return model;
-    });
-};
 
 const FIELD_TYPES = [
     {
@@ -363,206 +332,6 @@ const OKTA_OAUTH2_CLIENT_ID = readEnvValue('OKTA_OAUTH2_CLIENT_ID');
 const OKTA_OAUTH2_CLIENT_SECRET = readEnvValue('OKTA_OAUTH2_CLIENT_SECRET');
 const USE_OKTA_AUTH = !!(OKTA_OAUTH2_ISSUER && OKTA_OAUTH2_CLIENT_ID && OKTA_OAUTH2_CLIENT_SECRET);
 
-function formatAccountData(account, gt) {
-    account.type = {};
-
-    if (account.oauth2 && account.oauth2.app) {
-        let providerData = oauth2ProviderData(account.oauth2.app.provider);
-        account.type = providerData;
-    } else if (account.oauth2 && account.oauth2.provider) {
-        account.type = oauth2ProviderData(account.oauth2.provider);
-    } else if (account.imap && !account.imap.disabled) {
-        account.type.icon = 'fa fa-envelope-square';
-        account.type.name = 'IMAP';
-        account.type.comment = psl.get(account.imap.host) || account.imap.host;
-    } else if (account.smtp) {
-        account.type.icon = 'fa fa-paper-plane';
-        account.type.name = 'SMTP';
-        account.type.comment = psl.get(account.smtp.host) || account.smtp.host;
-    } else if (account.oauth2 && account.oauth2.auth && account.oauth2.auth.delegatedAccount) {
-        account.type.icon = 'fa fa-arrow-alt-circle-right';
-        account.type.name = gt.gettext('Delegated');
-        account.type.comment = util.format(gt.gettext('Using credentials from "%s"'), account.oauth2.auth.delegatedAccount);
-    } else {
-        account.type.name = 'N/A';
-    }
-
-    switch (account.state) {
-        case 'init':
-            account.stateLabel = {
-                type: 'info',
-                name: 'Initializing',
-                spinner: true
-            };
-            break;
-
-        case 'connecting':
-            account.stateLabel = {
-                type: 'info',
-                name: 'Connecting'
-            };
-            break;
-
-        case 'syncing':
-            account.stateLabel = {
-                type: 'info',
-                name: 'Syncing',
-                spinner: true
-            };
-            break;
-
-        case 'connected':
-            account.stateLabel = {
-                type: 'success',
-                name: 'Connected'
-            };
-            break;
-
-        case 'disabled':
-            account.stateLabel = {
-                type: 'secondary',
-                name: 'Disabled',
-                error: account.disabledReason
-            };
-            break;
-
-        case 'authenticationError':
-        case 'connectError': {
-            let errorMessage = account.lastErrorState ? account.lastErrorState.response : false;
-            if (account.lastErrorState) {
-                switch (account.lastErrorState.serverResponseCode) {
-                    case 'ETIMEDOUT':
-                        errorMessage = gt.gettext('Connection timed out. This usually occurs if you are behind a firewall or connecting to the wrong port.');
-                        break;
-                    case 'ClosedAfterConnectTLS':
-                        errorMessage = gt.gettext('The server unexpectedly closed the connection.');
-                        break;
-                    case 'ClosedAfterConnectText':
-                        errorMessage = gt.gettext(
-                            'The server unexpectedly closed the connection. This usually happens when attempting to connect to a TLS port without TLS enabled.'
-                        );
-                        break;
-                    case 'ECONNREFUSED':
-                        errorMessage = gt.gettext(
-                            'The server refused the connection. This typically occurs if the server is not running, is overloaded, or you are connecting to the wrong host or port.'
-                        );
-                        break;
-                }
-            }
-
-            account.stateLabel = {
-                type: 'danger',
-                name: 'Failed',
-                error: errorMessage
-            };
-            break;
-        }
-        case 'unset':
-            account.stateLabel = {
-                type: 'light',
-                name: 'Not syncing'
-            };
-            break;
-        case 'disconnected':
-            account.stateLabel = {
-                type: 'warning',
-                name: 'Disconnected'
-            };
-            break;
-        case 'paused':
-            account.stateLabel = {
-                type: 'secondary',
-                name: 'Paused'
-            };
-            break;
-        default:
-            account.stateLabel = {
-                type: 'secondary',
-                name: 'N/A'
-            };
-            break;
-    }
-
-    // Check if IMAP was disabled due to errors - override state label to show error
-    if (account.imap && account.imap.disabled && account.lastErrorState) {
-        account.stateLabel = {
-            type: 'danger',
-            name: 'Failed',
-            error: account.lastErrorState.description || account.lastErrorState.response
-        };
-    }
-
-    if (account.oauth2) {
-        account.oauth2.scopes = []
-            .concat(account.oauth2.scope || [])
-            .concat(account.oauth2.scopes || [])
-            .flatMap(entry => entry.split(/\s+/))
-            .map(entry => entry.trim())
-            .filter(entry => entry);
-
-        account.oauth2.expiresStr = account.oauth2.expires ? account.oauth2.expires.toISOString() : false;
-        account.oauth2.generatedStr = account.oauth2.generated ? account.oauth2.generated.toISOString() : false;
-
-        if (account.outlookSubscription) {
-            account.outlookSubscription.subscriptionExpiresStr = account.outlookSubscription.expirationDateTime
-                ? account.outlookSubscription.expirationDateTime.toISOString()
-                : false;
-
-            let state = account.outlookSubscription.state || {};
-
-            account.outlookSubscription.isValid =
-                state.state !== 'error' && account.outlookSubscription.expirationDateTime && account.outlookSubscription.expirationDateTime > new Date();
-
-            account.outlookSubscription.stateLabel = (state.state || '').replace(/^./, c => c.toUpperCase());
-
-            if ((state.state === 'created' && !account.outlookSubscription.expirationDateTime) || account.outlookSubscription.expirationDateTime < new Date()) {
-                account.outlookSubscription.stateLabel = 'Expired';
-            }
-        }
-    }
-
-    return account;
-}
-
-function formatServerState(state, payload) {
-    switch (state) {
-        case 'suspended':
-        case 'exited':
-        case 'disabled':
-            return {
-                type: 'warning',
-                name: state
-            };
-
-        case 'spawning':
-        case 'initializing':
-            return {
-                type: 'info',
-                name: state,
-                spinner: true
-            };
-
-        case 'listening':
-            return {
-                type: 'success',
-                name: state
-            };
-
-        case 'failed':
-            return {
-                type: 'danger',
-                name: state,
-                error: (payload && payload.error && payload.error.message) || null
-            };
-
-        default:
-            return {
-                type: 'secondary',
-                name: 'N/A'
-            };
-    }
-}
-
 async function getOpenAiError(gt) {
     let openAiError = await redis.get(`${REDIS_PREFIX}:openai:error`);
     if (openAiError) {
@@ -578,25 +347,6 @@ async function getOpenAiError(gt) {
         }
     }
     return openAiError;
-}
-
-async function getExampleDocumentsPayloads() {
-    let date = new Date().toISOString();
-
-    let examplePayloads = structuredClone(exampleDocumentsPayloads);
-
-    examplePayloads.forEach(payload => {
-        if (payload && payload.content) {
-            if (typeof payload.content.date === 'string') {
-                payload.content.date = date;
-            }
-
-            if (typeof payload.content.created === 'string') {
-                payload.content.created = date;
-            }
-        }
-    });
-    return examplePayloads;
 }
 
 async function getMailboxListing(accountObject) {
@@ -689,35 +439,15 @@ async function listPublicInterfaces(selectedAddresses) {
     });
 }
 
-async function getServerStatus(type) {
-    let serverStatus = await redis.hgetall(`${REDIS_PREFIX}${type}`);
-    let state = (serverStatus && serverStatus.state) || 'disabled';
-    let payload;
-    try {
-        payload = (serverStatus && typeof serverStatus.payload === 'string' && JSON.parse(serverStatus.payload)) || {};
-    } catch (err) {
-        // ignore
-    }
-
-    return { state, payload, label: formatServerState(state, payload) };
-}
-
 function applyRoutes(server, call) {
     // Initialize admin entity routes (webhooks, templates, gateways, tokens)
     adminEntitiesRoutes({ server, call });
 
-    // Export routes for session-authenticated UI
+    // SMTP deliverability test tool routes
+    smtpTestRoutes({ server, call });
 
-    function throwAsBoom(err) {
-        if (Boom.isBoom(err)) {
-            throw err;
-        }
-        let error = Boom.boomify(err, { statusCode: err.statusCode || 500 });
-        if (err.code) {
-            error.output.payload.code = err.code;
-        }
-        throw error;
-    }
+    // Public subscription-management (unsubscribe) routes
+    unsubscribeRoutes({ server, call });
 
     // Render-context booleans for the gmailService authMethod tab selector.
     // When `locked` is set the selector is shown but cannot be switched - the
@@ -8068,431 +7798,6 @@ Token: ${JSON.stringify(request.params.token)}`
                         .allow(false),
 
                     timezone: Joi.string().empty('').allow(false).max(255)
-                })
-            }
-        }
-    });
-
-    server.route({
-        method: 'POST',
-        path: '/admin/smtp/create-test',
-        async handler(request) {
-            let account = request.payload.account;
-
-            try {
-                request.logger.info({ msg: 'Request SMTP test', account });
-
-                let accountObject = new Account({ redis, account, call, secret: await getSecret() });
-
-                let accountData;
-                try {
-                    accountData = await accountObject.loadAccountData();
-                } catch (err) {
-                    return {
-                        error: err.message
-                    };
-                }
-
-                let headers = {
-                    'Content-Type': 'application/json',
-                    'User-Agent': `${packageData.name}/${packageData.version} (+${packageData.homepage})`
-                };
-
-                let res = await fetchCmd(`${SMTP_TEST_HOST}/test-address`, {
-                    method: 'post',
-                    body: JSON.stringify({
-                        version: packageData.version,
-                        requestor: '@postalsys/emailengine-app'
-                    }),
-                    headers,
-                    dispatcher: httpAgent.retry
-                });
-
-                if (!res.ok) {
-                    let err = new Error(res.statusText || `Invalid response: ${res.status} ${res.statusText}`);
-                    err.statusCode = res.status;
-
-                    try {
-                        err.response = await res.json();
-                    } catch (err) {
-                        // ignore
-                    }
-
-                    throw err;
-                }
-
-                let testAccount = await res.json();
-                if (!testAccount || !testAccount.user) {
-                    let err = new Error(`Invalid test account`);
-                    err.status = 500;
-
-                    try {
-                        err.response = testAccount;
-                    } catch (err) {
-                        // ignore
-                    }
-
-                    throw err;
-                }
-
-                try {
-                    let now = new Date().toISOString();
-                    let queueResponse = await accountObject.queueMessage(
-                        {
-                            account: accountData.account,
-                            subject: `Delivery test ${now}`,
-                            text: `Hello
-
-This is an automated email to test deliverability settings. If you see this email, you can safely delete it.
-
-${now}`,
-                            html: `<p>Hello</p>
-<p>This is an automated email to test deliverability settings. If you see this email, you can safely delete it.</p>
-<p>${now}</p>`,
-
-                            from: {
-                                name: accountData.name,
-                                address: accountData.email
-                            },
-                            to: [{ name: 'Delivery Test Server', address: testAccount.address }],
-                            copy: false,
-                            gateway: request.payload.gateway,
-                            feedbackKey: `${REDIS_PREFIX}test-send:${testAccount.user}`,
-                            deliveryAttempts: 1
-                        },
-                        { source: 'test' }
-                    );
-
-                    return Object.assign(testAccount, queueResponse || {});
-                } catch (err) {
-                    return {
-                        error: err.message
-                    };
-                }
-            } catch (err) {
-                request.logger.error({ msg: 'Failed to request test account', err, account });
-                return { success: false, error: err.message };
-            }
-        },
-        options: {
-            validate: {
-                options: {
-                    stripUnknown: true,
-                    abortEarly: false,
-                    convert: true
-                },
-
-                failAction,
-
-                payload: Joi.object({
-                    account: accountIdSchema.required(),
-                    gateway: Joi.string().empty('').max(256).example('sendgun').description('Gateway ID')
-                })
-            }
-        }
-    });
-
-    server.route({
-        method: 'POST',
-        path: '/admin/smtp/check-test',
-        async handler(request) {
-            let user = request.payload.user;
-
-            try {
-                request.logger.info({ msg: 'Request SMTP test response', user });
-
-                let deliveryStatus = (await redis.hgetall(`${REDIS_PREFIX}test-send:${user}`)) || {};
-                if (deliveryStatus.success === 'false') {
-                    let err = new Error(`Failed to deliver email: ${deliveryStatus.error}`);
-                    err.status = 500;
-                    throw err;
-                }
-
-                let headers = {
-                    'Content-Type': 'application/json',
-                    'User-Agent': `${packageData.name}/${packageData.version} (+${packageData.homepage})`
-                };
-
-                let res = await fetchCmd(`${SMTP_TEST_HOST}/test-address/${user}`, {
-                    method: 'get',
-                    headers,
-                    dispatcher: httpAgent.retry
-                });
-
-                if (!res.ok) {
-                    let err = new Error(res.statusText || `Invalid response: ${res.status} ${res.statusText}`);
-                    err.statusCode = res.status;
-
-                    try {
-                        err.response = await res.json();
-                    } catch (err) {
-                        // ignore
-                    }
-
-                    throw err;
-                }
-
-                let testResponse = await res.json();
-
-                if (testResponse) {
-                    let mainSig =
-                        testResponse.dkim &&
-                        testResponse.dkim.results &&
-                        testResponse.dkim.results.find(entry => entry && entry.status && entry.status.result === 'pass' && entry.status.aligned);
-
-                    if (!mainSig) {
-                        mainSig =
-                            testResponse.dkim &&
-                            testResponse.dkim.results &&
-                            testResponse.dkim.results.find(entry => entry && entry.status && entry.status.result === 'pass');
-                    }
-
-                    if (!mainSig) {
-                        mainSig = testResponse.dkim && testResponse.dkim.results && testResponse.dkim.results[0];
-                    }
-
-                    testResponse.mainSig = mainSig || {
-                        status: {
-                            result: 'none'
-                        }
-                    };
-
-                    if (testResponse.spf && testResponse.spf.status && testResponse.spf.status.comment) {
-                        testResponse.spf.status.comment = testResponse.spf.status.comment.replace(/^[^:\s]+:s*/, '');
-                    }
-                }
-
-                return testResponse;
-            } catch (err) {
-                request.logger.error({ msg: 'Failed to request test response', err, user });
-                return { status: 'error', error: err.message };
-            }
-        },
-        options: {
-            validate: {
-                options: {
-                    stripUnknown: true,
-                    abortEarly: false,
-                    convert: true
-                },
-
-                failAction,
-
-                payload: Joi.object({
-                    user: Joi.string().guid().description('Test ID')
-                })
-            }
-        }
-    });
-
-    server.route({
-        method: 'GET',
-        path: '/unsubscribe',
-        async handler(request, h) {
-            let data = Buffer.from(request.query.data, 'base64url').toString();
-            // do not check signature, validate fields in the submit step
-
-            data = JSON.parse(data);
-
-            if (!data || typeof data !== 'object' || data.act !== 'unsub') {
-                throw new Error(request.app.gt.gettext('Invalid input'));
-            }
-
-            // throws if account does not exist
-            let accountObject = new Account({ redis, account: data.acc });
-            await accountObject.loadAccountData();
-
-            return h.view(
-                'unsubscribe',
-                {
-                    pageTitleFull: request.app.gt.gettext('Subscription Management'),
-
-                    unsubscribed: await redis.hexists(`${REDIS_PREFIX}lists:unsub:entries:${data.list}`, data.rcpt),
-                    values: {
-                        listId: data.list,
-                        account: data.acc,
-                        messageId: data.msg,
-                        email: data.rcpt
-                    }
-                },
-                {
-                    layout: 'public'
-                }
-            );
-        },
-        options: {
-            auth: false,
-
-            validate: {
-                options: {
-                    stripUnknown: true,
-                    abortEarly: false,
-                    convert: true
-                },
-
-                async failAction(request, h, err) {
-                    request.logger.error({ msg: 'Failed to validate request arguments', err });
-                    let error = Boom.boomify(new Error(request.app.gt.gettext('Invalid request. Check your input and try again.')), { statusCode: 400 });
-                    if (err.code) {
-                        error.output.payload.code = err.code;
-                    }
-                    throw error;
-                },
-
-                query: Joi.object({
-                    data: Joi.string().base64({ paddingRequired: false, urlSafe: true }).required(),
-                    sig: Joi.string().base64({ paddingRequired: false, urlSafe: true })
-                })
-            }
-        }
-    });
-
-    server.route({
-        method: 'POST',
-        path: '/unsubscribe/address',
-        async handler(request, h) {
-            try {
-                // throws if account does not exist
-                let accountObject = new Account({ redis, account: request.payload.account });
-                await accountObject.loadAccountData();
-
-                let reSubscribed = false;
-
-                switch (request.payload.action) {
-                    case 'unsubscribe': {
-                        let isNew = await redis.eeListAdd(
-                            `${REDIS_PREFIX}lists:unsub:lists`,
-                            `${REDIS_PREFIX}lists:unsub:entries:${request.payload.listId}`,
-                            request.payload.listId,
-                            request.payload.email.toLowerCase().trim(),
-                            JSON.stringify({
-                                recipient: request.payload.email,
-                                account: request.payload.account,
-                                source: 'form',
-                                reason: 'unsubscribe',
-                                messageId: request.payload.messageId,
-                                remoteAddress: request.info.remoteAddress,
-                                userAgent: request.headers['user-agent'],
-                                created: new Date().toISOString()
-                            })
-                        );
-
-                        if (isNew) {
-                            await call({
-                                cmd: 'unsubscribe',
-                                account: request.payload.account,
-                                payload: {
-                                    recipient: request.payload.email,
-                                    messageId: request.payload.messageId,
-                                    listId: request.payload.listId,
-                                    remoteAddress: request.info.remoteAddress,
-                                    userAgent: request.headers['user-agent']
-                                }
-                            });
-                        }
-                        break;
-                    }
-
-                    case 'subscribe': {
-                        let removed = await redis.eeListRemove(
-                            `${REDIS_PREFIX}lists:unsub:lists`,
-                            `${REDIS_PREFIX}lists:unsub:entries:${request.payload.listId}`,
-                            request.payload.listId,
-                            request.payload.email.toLowerCase().trim()
-                        );
-
-                        if (removed) {
-                            await call({
-                                cmd: 'subscribe',
-                                account: request.payload.account,
-                                payload: {
-                                    recipient: request.payload.email,
-                                    messageId: request.payload.messageId,
-                                    listId: request.payload.listId,
-                                    remoteAddress: request.info.remoteAddress,
-                                    userAgent: request.headers['user-agent']
-                                }
-                            });
-                        }
-
-                        reSubscribed = true;
-                        break;
-                    }
-                }
-
-                return h.view(
-                    'unsubscribe',
-                    {
-                        pageTitleFull: request.app.gt.gettext('Subscription Management'),
-
-                        unsubscribed: await redis.hexists(`${REDIS_PREFIX}lists:unsub:entries:${request.payload.listId}`, request.payload.email),
-                        values: request.payload,
-                        reSubscribed
-                    },
-                    {
-                        layout: 'public'
-                    }
-                );
-            } catch (err) {
-                await request.flash({ type: 'danger', message: request.app.gt.gettext(`Couldn't process request. Try again.`) });
-                request.logger.error({ msg: 'Failed to process subscription request', err });
-
-                return h.view(
-                    'unsubscribe',
-                    {
-                        pageTitleFull: request.app.gt.gettext('Subscription Management'),
-                        unsubscribed: await redis.hexists(`${REDIS_PREFIX}lists:unsub:entries:${request.payload.listId}`, request.payload.email)
-                    },
-                    {
-                        layout: 'public'
-                    }
-                );
-            }
-        },
-        options: {
-            auth: false,
-            validate: {
-                options: {
-                    stripUnknown: true,
-                    abortEarly: false,
-                    convert: true
-                },
-
-                async failAction(request, h, err) {
-                    let errors = {};
-
-                    if (err.details) {
-                        err.details.forEach(detail => {
-                            if (!errors[detail.path]) {
-                                errors[detail.path] = detail.message;
-                            }
-                        });
-                    }
-
-                    await request.flash({ type: 'danger', message: request.app.gt.gettext(`Couldn't process request. Try again.`) });
-                    request.logger.error({ msg: 'Failed to process subscription request', err });
-
-                    return h
-                        .view(
-                            'unsubscribe',
-                            {
-                                pageTitleFull: request.app.gt.gettext('Subscription Management'),
-                                unsubscribed: await redis.hexists(`${REDIS_PREFIX}lists:unsub:entries:${request.payload.listId}`, request.payload.email),
-                                errors
-                            },
-                            {
-                                layout: 'public'
-                            }
-                        )
-                        .takeover();
-                },
-
-                payload: Joi.object({
-                    action: Joi.string().valid('subscribe', 'unsubscribe').required(),
-                    account: accountIdSchema.required(),
-                    listId: Joi.string().hostname().empty('').example('test-list').label('List ID').required(),
-                    email: Joi.string().email().empty('').required().description('Email address').required(),
-                    messageId: Joi.string().empty('').max(996).example('<test123@example.com>').description('Message ID')
                 })
             }
         }

--- a/lib/ui-routes/route-helpers.js
+++ b/lib/ui-routes/route-helpers.js
@@ -1,0 +1,314 @@
+'use strict';
+
+// Shared helpers used by more than one extracted UI route module - and still by
+// lib/routes-ui.js for the route groups not yet extracted. Lifting these here lets each
+// consumer import the single canonical copy instead of the monolith, so a route group can
+// be extracted without stranding a helper its sibling groups still need. Pure functions
+// and cached data only - this module registers no routes.
+//
+// Every symbol below was moved verbatim from lib/routes-ui.js. The only change is in
+// cachedTemplates: its __dirname-relative paths gain one extra '..' because this file
+// lives one directory deeper (lib/ui-routes/) than the original (lib/).
+
+const Boom = require('@hapi/boom');
+const util = require('util');
+const fs = require('fs');
+const pathlib = require('path');
+const psl = require('psl');
+
+const settings = require('../settings');
+const { redis } = require('../db');
+const { REDIS_PREFIX } = require('../consts');
+const { oauth2ProviderData } = require('../oauth2-apps');
+const exampleDocumentsPayloads = require('../payload-examples-documents.json');
+
+const OPEN_AI_MODELS = [
+    {
+        name: 'GPT-3 (instruct)',
+        id: 'gpt-3.5-turbo-instruct'
+    },
+
+    {
+        name: 'GPT-3 (chat)',
+        id: 'gpt-3.5-turbo'
+    },
+
+    {
+        name: 'GPT-4',
+        id: 'gpt-4'
+    }
+];
+
+const cachedTemplates = {
+    addressList: fs.readFileSync(pathlib.join(__dirname, '..', '..', 'views', 'partials', 'address_list.hbs'), 'utf-8'),
+    testSend: fs.readFileSync(pathlib.join(__dirname, '..', '..', 'views', 'partials', 'test_send.hbs'), 'utf-8')
+};
+
+const getOpenAiModels = async (models, selectedModel) => {
+    let modelList = (await settings.get('openAiModels')) || structuredClone(models);
+
+    if (selectedModel && !modelList.find(model => model.id === selectedModel)) {
+        modelList.unshift({
+            name: selectedModel,
+            id: selectedModel
+        });
+    }
+
+    return modelList.map(model => {
+        model.selected = model.id === selectedModel;
+        return model;
+    });
+};
+
+function formatAccountData(account, gt) {
+    account.type = {};
+
+    if (account.oauth2 && account.oauth2.app) {
+        let providerData = oauth2ProviderData(account.oauth2.app.provider);
+        account.type = providerData;
+    } else if (account.oauth2 && account.oauth2.provider) {
+        account.type = oauth2ProviderData(account.oauth2.provider);
+    } else if (account.imap && !account.imap.disabled) {
+        account.type.icon = 'fa fa-envelope-square';
+        account.type.name = 'IMAP';
+        account.type.comment = psl.get(account.imap.host) || account.imap.host;
+    } else if (account.smtp) {
+        account.type.icon = 'fa fa-paper-plane';
+        account.type.name = 'SMTP';
+        account.type.comment = psl.get(account.smtp.host) || account.smtp.host;
+    } else if (account.oauth2 && account.oauth2.auth && account.oauth2.auth.delegatedAccount) {
+        account.type.icon = 'fa fa-arrow-alt-circle-right';
+        account.type.name = gt.gettext('Delegated');
+        account.type.comment = util.format(gt.gettext('Using credentials from "%s"'), account.oauth2.auth.delegatedAccount);
+    } else {
+        account.type.name = 'N/A';
+    }
+
+    switch (account.state) {
+        case 'init':
+            account.stateLabel = {
+                type: 'info',
+                name: 'Initializing',
+                spinner: true
+            };
+            break;
+
+        case 'connecting':
+            account.stateLabel = {
+                type: 'info',
+                name: 'Connecting'
+            };
+            break;
+
+        case 'syncing':
+            account.stateLabel = {
+                type: 'info',
+                name: 'Syncing',
+                spinner: true
+            };
+            break;
+
+        case 'connected':
+            account.stateLabel = {
+                type: 'success',
+                name: 'Connected'
+            };
+            break;
+
+        case 'disabled':
+            account.stateLabel = {
+                type: 'secondary',
+                name: 'Disabled',
+                error: account.disabledReason
+            };
+            break;
+
+        case 'authenticationError':
+        case 'connectError': {
+            let errorMessage = account.lastErrorState ? account.lastErrorState.response : false;
+            if (account.lastErrorState) {
+                switch (account.lastErrorState.serverResponseCode) {
+                    case 'ETIMEDOUT':
+                        errorMessage = gt.gettext('Connection timed out. This usually occurs if you are behind a firewall or connecting to the wrong port.');
+                        break;
+                    case 'ClosedAfterConnectTLS':
+                        errorMessage = gt.gettext('The server unexpectedly closed the connection.');
+                        break;
+                    case 'ClosedAfterConnectText':
+                        errorMessage = gt.gettext(
+                            'The server unexpectedly closed the connection. This usually happens when attempting to connect to a TLS port without TLS enabled.'
+                        );
+                        break;
+                    case 'ECONNREFUSED':
+                        errorMessage = gt.gettext(
+                            'The server refused the connection. This typically occurs if the server is not running, is overloaded, or you are connecting to the wrong host or port.'
+                        );
+                        break;
+                }
+            }
+
+            account.stateLabel = {
+                type: 'danger',
+                name: 'Failed',
+                error: errorMessage
+            };
+            break;
+        }
+        case 'unset':
+            account.stateLabel = {
+                type: 'light',
+                name: 'Not syncing'
+            };
+            break;
+        case 'disconnected':
+            account.stateLabel = {
+                type: 'warning',
+                name: 'Disconnected'
+            };
+            break;
+        case 'paused':
+            account.stateLabel = {
+                type: 'secondary',
+                name: 'Paused'
+            };
+            break;
+        default:
+            account.stateLabel = {
+                type: 'secondary',
+                name: 'N/A'
+            };
+            break;
+    }
+
+    // Check if IMAP was disabled due to errors - override state label to show error
+    if (account.imap && account.imap.disabled && account.lastErrorState) {
+        account.stateLabel = {
+            type: 'danger',
+            name: 'Failed',
+            error: account.lastErrorState.description || account.lastErrorState.response
+        };
+    }
+
+    if (account.oauth2) {
+        account.oauth2.scopes = []
+            .concat(account.oauth2.scope || [])
+            .concat(account.oauth2.scopes || [])
+            .flatMap(entry => entry.split(/\s+/))
+            .map(entry => entry.trim())
+            .filter(entry => entry);
+
+        account.oauth2.expiresStr = account.oauth2.expires ? account.oauth2.expires.toISOString() : false;
+        account.oauth2.generatedStr = account.oauth2.generated ? account.oauth2.generated.toISOString() : false;
+
+        if (account.outlookSubscription) {
+            account.outlookSubscription.subscriptionExpiresStr = account.outlookSubscription.expirationDateTime
+                ? account.outlookSubscription.expirationDateTime.toISOString()
+                : false;
+
+            let state = account.outlookSubscription.state || {};
+
+            account.outlookSubscription.isValid =
+                state.state !== 'error' && account.outlookSubscription.expirationDateTime && account.outlookSubscription.expirationDateTime > new Date();
+
+            account.outlookSubscription.stateLabel = (state.state || '').replace(/^./, c => c.toUpperCase());
+
+            if ((state.state === 'created' && !account.outlookSubscription.expirationDateTime) || account.outlookSubscription.expirationDateTime < new Date()) {
+                account.outlookSubscription.stateLabel = 'Expired';
+            }
+        }
+    }
+
+    return account;
+}
+
+function formatServerState(state, payload) {
+    switch (state) {
+        case 'suspended':
+        case 'exited':
+        case 'disabled':
+            return {
+                type: 'warning',
+                name: state
+            };
+
+        case 'spawning':
+        case 'initializing':
+            return {
+                type: 'info',
+                name: state,
+                spinner: true
+            };
+
+        case 'listening':
+            return {
+                type: 'success',
+                name: state
+            };
+
+        case 'failed':
+            return {
+                type: 'danger',
+                name: state,
+                error: (payload && payload.error && payload.error.message) || null
+            };
+
+        default:
+            return {
+                type: 'secondary',
+                name: 'N/A'
+            };
+    }
+}
+
+async function getExampleDocumentsPayloads() {
+    let date = new Date().toISOString();
+
+    let examplePayloads = structuredClone(exampleDocumentsPayloads);
+
+    examplePayloads.forEach(payload => {
+        if (payload && payload.content) {
+            if (typeof payload.content.date === 'string') {
+                payload.content.date = date;
+            }
+
+            if (typeof payload.content.created === 'string') {
+                payload.content.created = date;
+            }
+        }
+    });
+    return examplePayloads;
+}
+
+async function getServerStatus(type) {
+    let serverStatus = await redis.hgetall(`${REDIS_PREFIX}${type}`);
+    let state = (serverStatus && serverStatus.state) || 'disabled';
+    let payload;
+    try {
+        payload = (serverStatus && typeof serverStatus.payload === 'string' && JSON.parse(serverStatus.payload)) || {};
+    } catch (err) {
+        // ignore
+    }
+
+    return { state, payload, label: formatServerState(state, payload) };
+}
+
+function throwAsBoom(err) {
+    if (Boom.isBoom(err)) {
+        throw err;
+    }
+    let error = Boom.boomify(err, { statusCode: err.statusCode || 500 });
+    if (err.code) {
+        error.output.payload.code = err.code;
+    }
+    throw error;
+}
+
+module.exports = {
+    OPEN_AI_MODELS,
+    cachedTemplates,
+    getOpenAiModels,
+    formatAccountData,
+    getExampleDocumentsPayloads,
+    getServerStatus,
+    throwAsBoom
+};

--- a/lib/ui-routes/smtp-test-routes.js
+++ b/lib/ui-routes/smtp-test-routes.js
@@ -1,0 +1,236 @@
+'use strict';
+
+// Admin UI routes for the SMTP deliverability test tool (the "Send a test email" feature
+// on an account page). Extracted verbatim from lib/routes-ui.js. These two endpoints call
+// the external Nodemailer test service (api.nodemailer.com) to send a probe message and
+// then fetch its DKIM/SPF analysis.
+
+const Joi = require('joi');
+const { fetch: fetchCmd } = require('undici');
+const { Account } = require('../account');
+const { redis } = require('../db');
+const getSecret = require('../get-secret');
+const { failAction, httpAgent } = require('../tools');
+const { accountIdSchema } = require('../schemas');
+const { REDIS_PREFIX } = require('../consts');
+const packageData = require('../../package.json');
+
+const SMTP_TEST_HOST = 'https://api.nodemailer.com';
+
+function init(args) {
+    const { server, call } = args;
+
+    server.route({
+        method: 'POST',
+        path: '/admin/smtp/create-test',
+        async handler(request) {
+            let account = request.payload.account;
+
+            try {
+                request.logger.info({ msg: 'Request SMTP test', account });
+
+                let accountObject = new Account({ redis, account, call, secret: await getSecret() });
+
+                let accountData;
+                try {
+                    accountData = await accountObject.loadAccountData();
+                } catch (err) {
+                    return {
+                        error: err.message
+                    };
+                }
+
+                let headers = {
+                    'Content-Type': 'application/json',
+                    'User-Agent': `${packageData.name}/${packageData.version} (+${packageData.homepage})`
+                };
+
+                let res = await fetchCmd(`${SMTP_TEST_HOST}/test-address`, {
+                    method: 'post',
+                    body: JSON.stringify({
+                        version: packageData.version,
+                        requestor: '@postalsys/emailengine-app'
+                    }),
+                    headers,
+                    dispatcher: httpAgent.retry
+                });
+
+                if (!res.ok) {
+                    let err = new Error(res.statusText || `Invalid response: ${res.status} ${res.statusText}`);
+                    err.statusCode = res.status;
+
+                    try {
+                        err.response = await res.json();
+                    } catch (err) {
+                        // ignore
+                    }
+
+                    throw err;
+                }
+
+                let testAccount = await res.json();
+                if (!testAccount || !testAccount.user) {
+                    let err = new Error(`Invalid test account`);
+                    err.status = 500;
+
+                    try {
+                        err.response = testAccount;
+                    } catch (err) {
+                        // ignore
+                    }
+
+                    throw err;
+                }
+
+                try {
+                    let now = new Date().toISOString();
+                    let queueResponse = await accountObject.queueMessage(
+                        {
+                            account: accountData.account,
+                            subject: `Delivery test ${now}`,
+                            text: `Hello
+
+This is an automated email to test deliverability settings. If you see this email, you can safely delete it.
+
+${now}`,
+                            html: `<p>Hello</p>
+<p>This is an automated email to test deliverability settings. If you see this email, you can safely delete it.</p>
+<p>${now}</p>`,
+
+                            from: {
+                                name: accountData.name,
+                                address: accountData.email
+                            },
+                            to: [{ name: 'Delivery Test Server', address: testAccount.address }],
+                            copy: false,
+                            gateway: request.payload.gateway,
+                            feedbackKey: `${REDIS_PREFIX}test-send:${testAccount.user}`,
+                            deliveryAttempts: 1
+                        },
+                        { source: 'test' }
+                    );
+
+                    return Object.assign(testAccount, queueResponse || {});
+                } catch (err) {
+                    return {
+                        error: err.message
+                    };
+                }
+            } catch (err) {
+                request.logger.error({ msg: 'Failed to request test account', err, account });
+                return { success: false, error: err.message };
+            }
+        },
+        options: {
+            validate: {
+                options: {
+                    stripUnknown: true,
+                    abortEarly: false,
+                    convert: true
+                },
+
+                failAction,
+
+                payload: Joi.object({
+                    account: accountIdSchema.required(),
+                    gateway: Joi.string().empty('').max(256).example('sendgun').description('Gateway ID')
+                })
+            }
+        }
+    });
+
+    server.route({
+        method: 'POST',
+        path: '/admin/smtp/check-test',
+        async handler(request) {
+            let user = request.payload.user;
+
+            try {
+                request.logger.info({ msg: 'Request SMTP test response', user });
+
+                let deliveryStatus = (await redis.hgetall(`${REDIS_PREFIX}test-send:${user}`)) || {};
+                if (deliveryStatus.success === 'false') {
+                    let err = new Error(`Failed to deliver email: ${deliveryStatus.error}`);
+                    err.status = 500;
+                    throw err;
+                }
+
+                let headers = {
+                    'Content-Type': 'application/json',
+                    'User-Agent': `${packageData.name}/${packageData.version} (+${packageData.homepage})`
+                };
+
+                let res = await fetchCmd(`${SMTP_TEST_HOST}/test-address/${user}`, {
+                    method: 'get',
+                    headers,
+                    dispatcher: httpAgent.retry
+                });
+
+                if (!res.ok) {
+                    let err = new Error(res.statusText || `Invalid response: ${res.status} ${res.statusText}`);
+                    err.statusCode = res.status;
+
+                    try {
+                        err.response = await res.json();
+                    } catch (err) {
+                        // ignore
+                    }
+
+                    throw err;
+                }
+
+                let testResponse = await res.json();
+
+                if (testResponse) {
+                    let mainSig =
+                        testResponse.dkim &&
+                        testResponse.dkim.results &&
+                        testResponse.dkim.results.find(entry => entry && entry.status && entry.status.result === 'pass' && entry.status.aligned);
+
+                    if (!mainSig) {
+                        mainSig =
+                            testResponse.dkim &&
+                            testResponse.dkim.results &&
+                            testResponse.dkim.results.find(entry => entry && entry.status && entry.status.result === 'pass');
+                    }
+
+                    if (!mainSig) {
+                        mainSig = testResponse.dkim && testResponse.dkim.results && testResponse.dkim.results[0];
+                    }
+
+                    testResponse.mainSig = mainSig || {
+                        status: {
+                            result: 'none'
+                        }
+                    };
+
+                    if (testResponse.spf && testResponse.spf.status && testResponse.spf.status.comment) {
+                        testResponse.spf.status.comment = testResponse.spf.status.comment.replace(/^[^:\s]+:s*/, '');
+                    }
+                }
+
+                return testResponse;
+            } catch (err) {
+                request.logger.error({ msg: 'Failed to request test response', err, user });
+                return { status: 'error', error: err.message };
+            }
+        },
+        options: {
+            validate: {
+                options: {
+                    stripUnknown: true,
+                    abortEarly: false,
+                    convert: true
+                },
+
+                failAction,
+
+                payload: Joi.object({
+                    user: Joi.string().guid().description('Test ID')
+                })
+            }
+        }
+    });
+}
+
+module.exports = init;

--- a/lib/ui-routes/unsubscribe-routes.js
+++ b/lib/ui-routes/unsubscribe-routes.js
@@ -1,0 +1,232 @@
+'use strict';
+
+// Public (unauthenticated) subscription-management routes. These render the unsubscribe
+// landing page reached from the List-Unsubscribe link in outgoing messages and process
+// the subscribe/unsubscribe form submission. Extracted verbatim from lib/routes-ui.js.
+// Both routes set `auth: false` and define their own validation failAction handlers.
+
+const Joi = require('joi');
+const Boom = require('@hapi/boom');
+const { Account } = require('../account');
+const { redis } = require('../db');
+const { accountIdSchema } = require('../schemas');
+const { REDIS_PREFIX } = require('../consts');
+
+function init(args) {
+    const { server, call } = args;
+
+    server.route({
+        method: 'GET',
+        path: '/unsubscribe',
+        async handler(request, h) {
+            let data = Buffer.from(request.query.data, 'base64url').toString();
+            // do not check signature, validate fields in the submit step
+
+            data = JSON.parse(data);
+
+            if (!data || typeof data !== 'object' || data.act !== 'unsub') {
+                throw new Error(request.app.gt.gettext('Invalid input'));
+            }
+
+            // throws if account does not exist
+            let accountObject = new Account({ redis, account: data.acc });
+            await accountObject.loadAccountData();
+
+            return h.view(
+                'unsubscribe',
+                {
+                    pageTitleFull: request.app.gt.gettext('Subscription Management'),
+
+                    unsubscribed: await redis.hexists(`${REDIS_PREFIX}lists:unsub:entries:${data.list}`, data.rcpt),
+                    values: {
+                        listId: data.list,
+                        account: data.acc,
+                        messageId: data.msg,
+                        email: data.rcpt
+                    }
+                },
+                {
+                    layout: 'public'
+                }
+            );
+        },
+        options: {
+            auth: false,
+
+            validate: {
+                options: {
+                    stripUnknown: true,
+                    abortEarly: false,
+                    convert: true
+                },
+
+                async failAction(request, h, err) {
+                    request.logger.error({ msg: 'Failed to validate request arguments', err });
+                    let error = Boom.boomify(new Error(request.app.gt.gettext('Invalid request. Check your input and try again.')), { statusCode: 400 });
+                    if (err.code) {
+                        error.output.payload.code = err.code;
+                    }
+                    throw error;
+                },
+
+                query: Joi.object({
+                    data: Joi.string().base64({ paddingRequired: false, urlSafe: true }).required(),
+                    sig: Joi.string().base64({ paddingRequired: false, urlSafe: true })
+                })
+            }
+        }
+    });
+
+    server.route({
+        method: 'POST',
+        path: '/unsubscribe/address',
+        async handler(request, h) {
+            try {
+                // throws if account does not exist
+                let accountObject = new Account({ redis, account: request.payload.account });
+                await accountObject.loadAccountData();
+
+                let reSubscribed = false;
+
+                switch (request.payload.action) {
+                    case 'unsubscribe': {
+                        let isNew = await redis.eeListAdd(
+                            `${REDIS_PREFIX}lists:unsub:lists`,
+                            `${REDIS_PREFIX}lists:unsub:entries:${request.payload.listId}`,
+                            request.payload.listId,
+                            request.payload.email.toLowerCase().trim(),
+                            JSON.stringify({
+                                recipient: request.payload.email,
+                                account: request.payload.account,
+                                source: 'form',
+                                reason: 'unsubscribe',
+                                messageId: request.payload.messageId,
+                                remoteAddress: request.info.remoteAddress,
+                                userAgent: request.headers['user-agent'],
+                                created: new Date().toISOString()
+                            })
+                        );
+
+                        if (isNew) {
+                            await call({
+                                cmd: 'unsubscribe',
+                                account: request.payload.account,
+                                payload: {
+                                    recipient: request.payload.email,
+                                    messageId: request.payload.messageId,
+                                    listId: request.payload.listId,
+                                    remoteAddress: request.info.remoteAddress,
+                                    userAgent: request.headers['user-agent']
+                                }
+                            });
+                        }
+                        break;
+                    }
+
+                    case 'subscribe': {
+                        let removed = await redis.eeListRemove(
+                            `${REDIS_PREFIX}lists:unsub:lists`,
+                            `${REDIS_PREFIX}lists:unsub:entries:${request.payload.listId}`,
+                            request.payload.listId,
+                            request.payload.email.toLowerCase().trim()
+                        );
+
+                        if (removed) {
+                            await call({
+                                cmd: 'subscribe',
+                                account: request.payload.account,
+                                payload: {
+                                    recipient: request.payload.email,
+                                    messageId: request.payload.messageId,
+                                    listId: request.payload.listId,
+                                    remoteAddress: request.info.remoteAddress,
+                                    userAgent: request.headers['user-agent']
+                                }
+                            });
+                        }
+
+                        reSubscribed = true;
+                        break;
+                    }
+                }
+
+                return h.view(
+                    'unsubscribe',
+                    {
+                        pageTitleFull: request.app.gt.gettext('Subscription Management'),
+
+                        unsubscribed: await redis.hexists(`${REDIS_PREFIX}lists:unsub:entries:${request.payload.listId}`, request.payload.email),
+                        values: request.payload,
+                        reSubscribed
+                    },
+                    {
+                        layout: 'public'
+                    }
+                );
+            } catch (err) {
+                await request.flash({ type: 'danger', message: request.app.gt.gettext(`Couldn't process request. Try again.`) });
+                request.logger.error({ msg: 'Failed to process subscription request', err });
+
+                return h.view(
+                    'unsubscribe',
+                    {
+                        pageTitleFull: request.app.gt.gettext('Subscription Management'),
+                        unsubscribed: await redis.hexists(`${REDIS_PREFIX}lists:unsub:entries:${request.payload.listId}`, request.payload.email)
+                    },
+                    {
+                        layout: 'public'
+                    }
+                );
+            }
+        },
+        options: {
+            auth: false,
+            validate: {
+                options: {
+                    stripUnknown: true,
+                    abortEarly: false,
+                    convert: true
+                },
+
+                async failAction(request, h, err) {
+                    let errors = {};
+
+                    if (err.details) {
+                        err.details.forEach(detail => {
+                            if (!errors[detail.path]) {
+                                errors[detail.path] = detail.message;
+                            }
+                        });
+                    }
+
+                    await request.flash({ type: 'danger', message: request.app.gt.gettext(`Couldn't process request. Try again.`) });
+                    request.logger.error({ msg: 'Failed to process subscription request', err });
+
+                    return h
+                        .view(
+                            'unsubscribe',
+                            {
+                                pageTitleFull: request.app.gt.gettext('Subscription Management'),
+                                unsubscribed: await redis.hexists(`${REDIS_PREFIX}lists:unsub:entries:${request.payload.listId}`, request.payload.email),
+                                errors
+                            },
+                            {
+                                layout: 'public'
+                            }
+                        )
+                        .takeover();
+                },
+
+                payload: Joi.object({
+                    action: Joi.string().valid('subscribe', 'unsubscribe').required(),
+                    account: accountIdSchema.required(),
+                    listId: Joi.string().hostname().empty('').example('test-list').label('List ID').required(),
+                    email: Joi.string().email().empty('').required().description('Email address').required(),
+                    messageId: Joi.string().empty('').max(996).example('<test123@example.com>').description('Message ID')
+                })
+            }
+        }
+    });
+}
+
+module.exports = init;

--- a/test/ui-routes-size-test.js
+++ b/test/ui-routes-size-test.js
@@ -1,0 +1,32 @@
+'use strict';
+
+// Size ratchet (tripwire) for the routes-ui.js god file.
+//
+// lib/routes-ui.js is being decomposed into focused modules under lib/ui-routes/. This
+// test asserts the monolith never grows past BUDGET. The ratchet only moves DOWN: after
+// each extraction batch lands, lower BUDGET to the file's new line count. That makes any
+// future growth of the monolith a failing test, so the file cannot quietly regrow while
+// the extraction is in progress (and stays capped afterwards).
+//
+// Pure filesystem read - no Redis, no server, exits cleanly on its own.
+
+const test = require('node:test');
+const assert = require('node:assert').strict;
+const fs = require('fs');
+const pathlib = require('path');
+
+// Lower this after every extraction batch to the new `wc -l lib/routes-ui.js`.
+const BUDGET = 8143;
+
+test('routes-ui.js stays within the size budget', () => {
+    const filePath = pathlib.join(__dirname, '..', 'lib', 'routes-ui.js');
+    // Count newlines to match `wc -l` so BUDGET maps directly to that command's output.
+    const lineCount = (fs.readFileSync(filePath, 'utf-8').match(/\n/g) || []).length;
+
+    assert.ok(
+        lineCount <= BUDGET,
+        `lib/routes-ui.js has ${lineCount} lines, exceeding the budget of ${BUDGET}. ` +
+            `Extract routes into lib/ui-routes/ instead of growing the monolith. ` +
+            `If a deliberate, reviewed increase is required, raise BUDGET in this test.`
+    );
+});

--- a/test/ui-routes-smoke-test.js
+++ b/test/ui-routes-smoke-test.js
@@ -1,0 +1,89 @@
+'use strict';
+
+// Runtime smoke test for the admin UI routes, complementing the in-process route-table
+// snapshot in test/ui-routes-table-test.js.
+//
+// The table test proves the exact SET of registered routes is unchanged across the
+// routes-ui.js -> ui-routes/ extraction. This test proves the GET page handlers still
+// EXECUTE end-to-end after a move - i.e. the extracted module's requires and shared
+// helpers are wired correctly and nothing throws at runtime.
+//
+// It targets the two failure modes a move can introduce, and ONLY those:
+//   - a dropped/renamed route  -> 404 (route no longer registered)
+//   - a broken require / missing symbol in the new module -> 5xx (handler crashes)
+// So each route must respond with something OTHER than 404 and below 500. We deliberately
+// do NOT assert a specific 2xx/3xx: the shared test server's auth state depends on what
+// earlier tests configured (an unauthenticated /admin page may legitimately 302 to the
+// login screen, or 200 when no admin password is set), and either is fine here.
+//
+// Only parameterless GET routes are probed - a route with a path parameter (e.g.
+// /admin/accounts/{account}) cannot distinguish "route dropped" (404) from "handler
+// returned not-found for a bogus id" (also 404). Those, plus all POST routes, are covered
+// by the route-table snapshot test instead.
+//
+// Runs against the shared test server started by the Grunt test task (config/test.toml,
+// port 7077), same harness as test/api-routes-smoke-test.js.
+
+require('dotenv').config({ quiet: true });
+
+const config = require('@zone-eu/wild-config');
+const supertest = require('supertest');
+const test = require('node:test');
+const assert = require('node:assert').strict;
+
+const baseUrl = `http://127.0.0.1:${config.api.port}`;
+
+// Parameterless GET routes from the UI route table (test/ui-routes-table-test.js golden).
+// Routes with a `{param}` segment and all POST routes are intentionally excluded (see header).
+const GET_ROUTES = [
+    '/accounts/new',
+    '/admin',
+    '/admin/account/password',
+    '/admin/account/security',
+    '/admin/accounts',
+    '/admin/config/ai',
+    '/admin/config/document-store',
+    '/admin/config/document-store/chat',
+    '/admin/config/document-store/mappings',
+    '/admin/config/document-store/mappings/new',
+    '/admin/config/document-store/pre-processing',
+    '/admin/config/imap-proxy',
+    '/admin/config/license',
+    '/admin/config/logging',
+    '/admin/config/network',
+    '/admin/config/oauth',
+    '/admin/config/oauth/new',
+    '/admin/config/oauth/subscriptions',
+    '/admin/config/service',
+    '/admin/config/smtp',
+    '/admin/config/webhooks',
+    '/admin/gateways',
+    '/admin/gateways/new',
+    '/admin/internals',
+    '/admin/legal',
+    '/admin/login',
+    '/admin/swagger',
+    '/admin/templates',
+    '/admin/templates/new',
+    '/admin/tokens',
+    '/admin/tokens/new',
+    // NOTE: GET /admin/totp is intentionally omitted. Its handler reads the logged-in
+    // user off request.auth.credentials, so a direct GET without a partial-auth login
+    // session returns a pre-existing 500 (lib/routes-ui.js, the 2FA page). That is not a
+    // regression this refactor can cause; the route's registration is still covered by
+    // the route-table snapshot test.
+    '/admin/upgrade',
+    '/admin/webhooks',
+    '/admin/webhooks/new',
+    '/unsubscribe'
+];
+
+test('Admin UI routes smoke test', async t => {
+    await t.test('every parameterless GET route is registered and does not crash', async () => {
+        for (const path of GET_ROUTES) {
+            const res = await supertest(baseUrl).get(path);
+            assert.notEqual(res.status, 404, `GET ${path} returned 404 - route is not registered (dropped or renamed during extraction)`);
+            assert.ok(res.status < 500, `GET ${path} returned ${res.status} - handler crashed (likely a broken require or missing symbol after extraction)`);
+        }
+    });
+});

--- a/test/ui-routes-table-test.js
+++ b/test/ui-routes-table-test.js
@@ -1,0 +1,233 @@
+'use strict';
+
+// In-process route-table snapshot for the admin UI routes.
+//
+// This is the primary guardrail for the routes-ui.js -> ui-routes/ extraction. The
+// extraction moves route handlers verbatim out of the lib/routes-ui.js monolith into
+// focused modules under lib/ui-routes/, then wires each module back in from within
+// applyRoutes(). Moving code must NOT change which routes are registered.
+//
+// We capture the exact set of (METHOD, path) pairs that routes-ui.js registers by
+// invoking it with a mock Hapi server whose .route() simply records the route config.
+// Route registration is synchronous and never touches Redis or the `call` RPC, so a
+// bare mock is sufficient - handlers reference external state only inside their (never
+// executed) closures. The captured set must equal the checked-in golden list below,
+// and there must be no duplicate registrations.
+//
+// IMPORTANT: GOLDEN_ROUTES must stay byte-for-byte identical across every extraction
+// batch. It changes ONLY when a route is intentionally added or removed by feature work
+// (not by this refactor). A diff here means a route was dropped, duplicated, or its
+// method/path was altered during a move - exactly the failure modes the extraction risks.
+//
+// server.table() is unreachable from the external Grunt test process and the Swagger
+// spec omits UI routes, so this must run in-process. Because requiring routes-ui.js
+// transitively opens a Redis connection and BullMQ queues (lib/db.js), the test force
+// exits after running, mirroring the convention in test/tokens-test.js.
+
+const test = require('node:test');
+const assert = require('node:assert').strict;
+
+const { redis } = require('../lib/db');
+
+// The complete, sorted set of routes registered by lib/routes-ui.js (including the
+// already-extracted admin-entities-routes.js it wires in). 128 routes.
+const GOLDEN_ROUTES = [
+    'DELETE /admin/accounts/{account}/export/{exportId}',
+    'GET /.well-known/acme-challenge/{token}',
+    'GET /accounts/new',
+    'GET /admin',
+    'GET /admin/account/password',
+    'GET /admin/account/security',
+    'GET /admin/accounts',
+    'GET /admin/accounts/{account}',
+    'GET /admin/accounts/{account}/browse',
+    'GET /admin/accounts/{account}/edit',
+    'GET /admin/accounts/{account}/export/{exportId}',
+    'GET /admin/accounts/{account}/export/{exportId}/download',
+    'GET /admin/accounts/{account}/exports',
+    'GET /admin/accounts/{account}/logs.txt',
+    'GET /admin/config/ai',
+    'GET /admin/config/document-store',
+    'GET /admin/config/document-store/chat',
+    'GET /admin/config/document-store/mappings',
+    'GET /admin/config/document-store/mappings/new',
+    'GET /admin/config/document-store/pre-processing',
+    'GET /admin/config/imap-proxy',
+    'GET /admin/config/license',
+    'GET /admin/config/logging',
+    'GET /admin/config/network',
+    'GET /admin/config/oauth',
+    'GET /admin/config/oauth/app/{app}',
+    'GET /admin/config/oauth/edit/{app}',
+    'GET /admin/config/oauth/new',
+    'GET /admin/config/oauth/subscriptions',
+    'GET /admin/config/service',
+    'GET /admin/config/smtp',
+    'GET /admin/config/webhooks',
+    'GET /admin/gateways',
+    'GET /admin/gateways/edit/{gateway}',
+    'GET /admin/gateways/gateway/{gateway}',
+    'GET /admin/gateways/new',
+    'GET /admin/internals',
+    'GET /admin/internals/thread/{threadId}',
+    'GET /admin/legal',
+    'GET /admin/login',
+    'GET /admin/logout',
+    'GET /admin/swagger',
+    'GET /admin/templates',
+    'GET /admin/templates/new',
+    'GET /admin/templates/template/{template}',
+    'GET /admin/templates/template/{template}/edit',
+    'GET /admin/tokens',
+    'GET /admin/tokens/new',
+    'GET /admin/totp',
+    'GET /admin/upgrade',
+    'GET /admin/webhooks',
+    'GET /admin/webhooks/new',
+    'GET /admin/webhooks/webhook/{webhook}',
+    'GET /admin/webhooks/webhook/{webhook}/edit',
+    'GET /unsubscribe',
+    'POST /accounts/new',
+    'POST /accounts/new/imap',
+    'POST /accounts/new/imap/server',
+    'POST /accounts/new/imap/test',
+    'POST /admin/account/logout-all',
+    'POST /admin/account/passkeys/delete',
+    'POST /admin/account/passkeys/register/options',
+    'POST /admin/account/passkeys/register/verify',
+    'POST /admin/account/password',
+    'POST /admin/account/tfa/disable',
+    'POST /admin/account/tfa/enable',
+    'POST /admin/accounts/new',
+    'POST /admin/accounts/{account}/delete',
+    'POST /admin/accounts/{account}/edit',
+    'POST /admin/accounts/{account}/export',
+    'POST /admin/accounts/{account}/logs',
+    'POST /admin/accounts/{account}/logs-flush',
+    'POST /admin/accounts/{account}/reconnect',
+    'POST /admin/accounts/{account}/sync',
+    'POST /admin/config/ai',
+    'POST /admin/config/ai/reload-models',
+    'POST /admin/config/ai/test-prompt',
+    'POST /admin/config/browser',
+    'POST /admin/config/clear-error',
+    'POST /admin/config/document-store',
+    'POST /admin/config/document-store/chat',
+    'POST /admin/config/document-store/mappings/new',
+    'POST /admin/config/document-store/pre-processing',
+    'POST /admin/config/document-store/test',
+    'POST /admin/config/imap-proxy',
+    'POST /admin/config/license',
+    'POST /admin/config/license/delete',
+    'POST /admin/config/license/trial',
+    'POST /admin/config/logging',
+    'POST /admin/config/logging/reconnect',
+    'POST /admin/config/network',
+    'POST /admin/config/network/delete',
+    'POST /admin/config/network/reload',
+    'POST /admin/config/oauth/app/{app}/add-account',
+    'POST /admin/config/oauth/delete',
+    'POST /admin/config/oauth/edit',
+    'POST /admin/config/oauth/new',
+    'POST /admin/config/oauth/subscriptions',
+    'POST /admin/config/oauth/verify/{app}',
+    'POST /admin/config/service',
+    'POST /admin/config/service/clean',
+    'POST /admin/config/service/preview',
+    'POST /admin/config/smtp',
+    'POST /admin/config/smtp/certificate',
+    'POST /admin/config/webhooks',
+    'POST /admin/config/webhooks/test',
+    'POST /admin/gateways/delete/{gateway}',
+    'POST /admin/gateways/edit',
+    'POST /admin/gateways/new',
+    'POST /admin/gateways/test',
+    'POST /admin/internals/kill',
+    'POST /admin/internals/snapshot',
+    'POST /admin/login',
+    'POST /admin/passkey/auth/options',
+    'POST /admin/passkey/auth/verify',
+    'POST /admin/smtp/check-test',
+    'POST /admin/smtp/create-test',
+    'POST /admin/templates/delete',
+    'POST /admin/templates/edit',
+    'POST /admin/templates/new',
+    'POST /admin/templates/test',
+    'POST /admin/tokens/delete',
+    'POST /admin/tokens/new',
+    'POST /admin/totp',
+    'POST /admin/webhooks/delete',
+    'POST /admin/webhooks/edit',
+    'POST /admin/webhooks/new',
+    'POST /unsubscribe/address'
+];
+
+// Capture every route registered by routes-ui.js using a mock server.
+function captureRoutes() {
+    const captured = [];
+
+    const record = cfg => {
+        if (Array.isArray(cfg)) {
+            cfg.forEach(record);
+            return;
+        }
+        const methods = Array.isArray(cfg.method) ? cfg.method : [cfg.method];
+        for (const method of methods) {
+            captured.push(`${String(method).toUpperCase()} ${cfg.path}`);
+        }
+    };
+
+    // Mock Hapi server. routes-ui.js (and the modules it wires) only call server.route()
+    // at registration time; server.auth is touched only inside a handler. Any other
+    // server.* access returns a harmless no-op.
+    const mockServer = new Proxy(
+        {
+            route: record,
+            auth: { settings: { default: null }, default() {} }
+        },
+        {
+            get(target, prop) {
+                if (prop in target) {
+                    return target[prop];
+                }
+                return () => {};
+            }
+        }
+    );
+
+    // `call` is only awaited inside handlers, never during registration.
+    const mockCall = async () => ({});
+
+    const routesUi = require('../lib/routes-ui');
+    routesUi(mockServer, mockCall);
+
+    return captured;
+}
+
+test('UI route table is unchanged', async t => {
+    t.after(() => {
+        redis.quit();
+        // Force exit after cleanup - requiring routes-ui.js opens Redis/BullMQ handles.
+        setTimeout(() => process.exit(), 1000).unref();
+    });
+
+    const captured = captureRoutes();
+    const unique = [...new Set(captured)].sort();
+
+    await t.test('no duplicate route registrations', () => {
+        assert.equal(captured.length, unique.length, `expected no duplicate (method, path) registrations, got ${captured.length - unique.length} duplicate(s)`);
+    });
+
+    await t.test('registered routes match the golden snapshot exactly', () => {
+        const golden = [...GOLDEN_ROUTES].sort();
+
+        const missing = golden.filter(r => !unique.includes(r));
+        const added = unique.filter(r => !golden.includes(r));
+
+        assert.deepEqual(
+            unique,
+            golden,
+            `UI route table changed.\n  Dropped (in golden, not registered): ${JSON.stringify(missing)}\n  New (registered, not in golden): ${JSON.stringify(added)}`
+        );
+    });
+});


### PR DESCRIPTION
## What & why

First milestone of decomposing the `lib/routes-ui.js` god file (8,838 lines) into focused modules under `lib/ui-routes/` — tech-debt item **A2**. All route/helper moves are **behavior-preserving (verbatim)**; the registered route table is provably unchanged.

`lib/routes-ui.js`: **8,838 -> 8,143 lines.**

## Guardrails (run on every future batch)

- **`test/ui-routes-table-test.js`** - in-process snapshot of the exact `(method, path)` set registered by `routes-ui.js` (128 routes). The invariant proving no route is dropped, added, or duplicated by a move. Runs against a mock Hapi server, no live server needed.
- **`test/ui-routes-smoke-test.js`** - HTTP reachability of every parameterless `/admin/*` GET (not 404, not 5xx), mirroring `api-routes-smoke-test.js`.
- **`test/ui-routes-size-test.js`** - line-count ratchet so `routes-ui.js` cannot regrow (lowered after each batch).

## Extractions

- **`lib/ui-routes/route-helpers.js`** - shared pure helpers used across route groups (`throwAsBoom`, `formatAccountData`, `formatServerState`, `getServerStatus`, `getOpenAiModels`/`OPEN_AI_MODELS`, `getExampleDocumentsPayloads`, `cachedTemplates`), imported back into `routes-ui.js`.
- **`lib/ui-routes/smtp-test-routes.js`** - `/admin/smtp/create-test`, `/admin/smtp/check-test`.
- **`lib/ui-routes/unsubscribe-routes.js`** - public `/unsubscribe`, `/unsubscribe/address`.

Wiring mirrors the existing `admin-entities-routes.js` pattern (`init({ server, call })` invoked inside `applyRoutes`).

## Verification

- Route table byte-for-byte unchanged (snapshot test); full server boots cleanly; extracted routes confirmed registered (POSTs return 403/CSRF as before, 0 server 5xx).
- ESLint + Prettier clean; `/simplify` and `/security-review` run (no new issues).

🤖 Generated with [Claude Code](https://claude.com/claude-code)