### PR TITLE
refactor: extract dashboard and info-page routes (A2 batch 4)

### DIFF
--- a/lib/routes-ui.js
+++ b/lib/routes-ui.js
@@ -14,7 +14,6 @@ const {
     verifyAccountInfo,
     getLogs,
     flattenObjectKeys,
-    getStats,
     getBoolean,
     getSignedFormData,
     readEnvValue,
@@ -68,6 +67,7 @@ const adminEntitiesRoutes = require('./ui-routes/admin-entities-routes');
 const smtpTestRoutes = require('./ui-routes/smtp-test-routes');
 const unsubscribeRoutes = require('./ui-routes/unsubscribe-routes');
 const internalsRoutes = require('./ui-routes/internals-routes');
+const dashboardRoutes = require('./ui-routes/dashboard-routes');
 const {
     throwAsBoom,
     formatAccountData,
@@ -99,8 +99,7 @@ const {
     DEFAULT_MAX_BODY_SIZE,
     DEFAULT_MAX_PAYLOAD_TIMEOUT,
     MAX_FORM_TTL,
-    NONCE_BYTES,
-    ALLOWED_REDIS_LATENCY
+    NONCE_BYTES
 } = consts;
 
 config.api = config.api || {
@@ -453,6 +452,9 @@ function applyRoutes(server, call) {
     // System internals / threads tools routes
     internalsRoutes({ server, call });
 
+    // Dashboard and standalone informational pages (swagger, legal, upgrade)
+    dashboardRoutes({ server, call });
+
     // Render-context booleans for the gmailService authMethod tab selector.
     // When `locked` is set the selector is shown but cannot be switched - the
     // authentication method is fixed once an app has been created.
@@ -679,178 +681,6 @@ function applyRoutes(server, call) {
         await call({
             cmd: 'openAiDefaultPrompt'
         });
-
-    server.route({
-        method: 'GET',
-        path: '/admin',
-        async handler(request, h) {
-            let stats = await getStats(redis, call, request.query.seconds || 24 * 3600);
-
-            let counterList = [
-                {
-                    key: 'events:messageNew',
-                    title: 'New emails',
-                    color: 'primary',
-                    icon: 'envelope',
-                    comment: 'Detected new emails in IMAP mailboxes.'
-                },
-                {
-                    key: 'webhooks:success',
-                    title: 'Webhooks sent',
-                    color: 'primary',
-                    icon: 'network-wired',
-                    comment: 'Count of successfully delivered webhooks.'
-                },
-                {
-                    key: 'webhooks:fail',
-                    title: 'Webhooks failed',
-                    color: 'danger',
-                    icon: 'network-wired',
-                    comment: 'Count of webhooks that failed to deliver.'
-                },
-                {
-                    key: 'submit:success',
-                    title: 'Emails sent',
-                    color: 'primary',
-                    icon: 'mail-bulk',
-                    comment: 'Count of emails sent to MTA servers.'
-                },
-                {
-                    key: 'submit:fail',
-                    title: 'Emails rejected',
-                    color: 'danger',
-                    icon: 'mail-bulk',
-                    comment: 'Count of emails rejected by MTA servers.'
-                },
-                {
-                    key: 'apiCall:success',
-                    title: 'Successful API calls',
-                    color: 'primary',
-                    icon: 'file-code',
-                    comment: 'Successful API calls with positive responses.'
-                },
-                {
-                    key: 'apiCall:fail',
-                    title: 'Failed API calls',
-                    color: 'danger',
-                    icon: 'file-code',
-                    comment: 'API calls that returned error responses.'
-                }
-            ];
-
-            for (let counter of counterList) {
-                counter.value = stats.counters[counter.key] || 0;
-            }
-
-            let hasAccounts = !!stats.accounts;
-            stats.connectedAccounts = (stats.connections.connected || 0) + (stats.connections.syncing || 0);
-
-            let defaultLocale = (await settings.get('locale')) || 'en';
-
-            let nrFormatter;
-
-            let nrFormatterOpts = {
-                style: 'decimal'
-            };
-
-            try {
-                nrFormatter = new Intl.NumberFormat(defaultLocale, nrFormatterOpts);
-            } catch (err) {
-                nrFormatter = new Intl.NumberFormat('en-US', nrFormatterOpts);
-            }
-
-            return h.view(
-                'dashboard',
-                {
-                    pageTitle: 'Dashboard',
-                    menuDashboard: true,
-                    stats,
-                    counterList,
-                    hasAccounts,
-
-                    redisWarnings: stats.redisWarnings || [],
-
-                    redisPing: {
-                        key: 'redisPing',
-                        title: 'Redis Latency',
-                        color: typeof stats.redisPing !== 'number' ? 'warning' : stats.redisPing < ALLOWED_REDIS_LATENCY ? 'success' : 'danger',
-                        icon: 'clock',
-                        comment: 'How many milliseconds does it take to run a Redis command',
-                        value: typeof stats.redisPing !== 'number' ? '\u2013' : nrFormatter.format(stats.redisPing / 1000000)
-                    }
-                },
-                {
-                    layout: 'app'
-                }
-            );
-        }
-    });
-
-    server.route({
-        method: 'GET',
-        path: '/admin/swagger',
-        async handler(request, h) {
-            return h.view(
-                'swagger/index',
-                {
-                    pageTitle: 'API Reference',
-                    menuSwagger: true,
-                    injectHtmlHead: `<link rel="stylesheet" type="text/css" href="/admin/swagger/resources/swagger-ui.css" />
-<style>
-    .download-url-wrapper,
-    .topbar {
-        display: none !important;
-    }
-</style>`
-                },
-                {
-                    layout: 'app'
-                }
-            );
-        }
-    });
-
-    server.route({
-        method: 'GET',
-        path: '/admin/legal',
-        async handler(request, h) {
-            return h.view(
-                'legal',
-                {
-                    pageTitle: 'Legal',
-                    menuLegal: true
-                },
-                {
-                    layout: 'app'
-                }
-            );
-        }
-    });
-
-    server.route({
-        method: 'GET',
-        path: '/admin/upgrade',
-        async handler(request, h) {
-            const isDO = getBoolean(readEnvValue('EENGINE_DOCEAN'));
-            const isScriptInstalled = getBoolean(readEnvValue('EENGINE_INSTALL_SCRIPT'));
-            const isRender = typeof readEnvValue('RENDER_SERVICE_SLUG') === 'string' && readEnvValue('RENDER_SERVICE_SLUG');
-            const isGeneral = !isDO && !isRender && !isScriptInstalled;
-
-            return h.view(
-                'upgrade',
-                {
-                    pageTitle: 'Upgrade',
-                    isDO,
-                    isRender,
-                    isScriptInstalled,
-                    isGeneral
-                },
-                {
-                    layout: 'app'
-                }
-            );
-        }
-    });
 
     server.route({
         method: 'GET',

--- a/lib/ui-routes/dashboard-routes.js
+++ b/lib/ui-routes/dashboard-routes.js
@@ -1,0 +1,188 @@
+'use strict';
+
+// Admin UI routes for the dashboard and standalone informational pages: the main
+// /admin dashboard (stats counters), the Swagger API reference, the legal page, and the
+// upgrade page. Extracted verbatim from lib/routes-ui.js.
+
+const { getStats, getBoolean, readEnvValue } = require('../tools');
+const settings = require('../settings');
+const { redis } = require('../db');
+const { ALLOWED_REDIS_LATENCY } = require('../consts');
+
+function init(args) {
+    const { server, call } = args;
+
+    server.route({
+        method: 'GET',
+        path: '/admin',
+        async handler(request, h) {
+            let stats = await getStats(redis, call, request.query.seconds || 24 * 3600);
+
+            let counterList = [
+                {
+                    key: 'events:messageNew',
+                    title: 'New emails',
+                    color: 'primary',
+                    icon: 'envelope',
+                    comment: 'Detected new emails in IMAP mailboxes.'
+                },
+                {
+                    key: 'webhooks:success',
+                    title: 'Webhooks sent',
+                    color: 'primary',
+                    icon: 'network-wired',
+                    comment: 'Count of successfully delivered webhooks.'
+                },
+                {
+                    key: 'webhooks:fail',
+                    title: 'Webhooks failed',
+                    color: 'danger',
+                    icon: 'network-wired',
+                    comment: 'Count of webhooks that failed to deliver.'
+                },
+                {
+                    key: 'submit:success',
+                    title: 'Emails sent',
+                    color: 'primary',
+                    icon: 'mail-bulk',
+                    comment: 'Count of emails sent to MTA servers.'
+                },
+                {
+                    key: 'submit:fail',
+                    title: 'Emails rejected',
+                    color: 'danger',
+                    icon: 'mail-bulk',
+                    comment: 'Count of emails rejected by MTA servers.'
+                },
+                {
+                    key: 'apiCall:success',
+                    title: 'Successful API calls',
+                    color: 'primary',
+                    icon: 'file-code',
+                    comment: 'Successful API calls with positive responses.'
+                },
+                {
+                    key: 'apiCall:fail',
+                    title: 'Failed API calls',
+                    color: 'danger',
+                    icon: 'file-code',
+                    comment: 'API calls that returned error responses.'
+                }
+            ];
+
+            for (let counter of counterList) {
+                counter.value = stats.counters[counter.key] || 0;
+            }
+
+            let hasAccounts = !!stats.accounts;
+            stats.connectedAccounts = (stats.connections.connected || 0) + (stats.connections.syncing || 0);
+
+            let defaultLocale = (await settings.get('locale')) || 'en';
+
+            let nrFormatter;
+
+            let nrFormatterOpts = {
+                style: 'decimal'
+            };
+
+            try {
+                nrFormatter = new Intl.NumberFormat(defaultLocale, nrFormatterOpts);
+            } catch (err) {
+                nrFormatter = new Intl.NumberFormat('en-US', nrFormatterOpts);
+            }
+
+            return h.view(
+                'dashboard',
+                {
+                    pageTitle: 'Dashboard',
+                    menuDashboard: true,
+                    stats,
+                    counterList,
+                    hasAccounts,
+
+                    redisWarnings: stats.redisWarnings || [],
+
+                    redisPing: {
+                        key: 'redisPing',
+                        title: 'Redis Latency',
+                        color: typeof stats.redisPing !== 'number' ? 'warning' : stats.redisPing < ALLOWED_REDIS_LATENCY ? 'success' : 'danger',
+                        icon: 'clock',
+                        comment: 'How many milliseconds does it take to run a Redis command',
+                        value: typeof stats.redisPing !== 'number' ? '\u2013' : nrFormatter.format(stats.redisPing / 1000000)
+                    }
+                },
+                {
+                    layout: 'app'
+                }
+            );
+        }
+    });
+
+    server.route({
+        method: 'GET',
+        path: '/admin/swagger',
+        async handler(request, h) {
+            return h.view(
+                'swagger/index',
+                {
+                    pageTitle: 'API Reference',
+                    menuSwagger: true,
+                    injectHtmlHead: `<link rel="stylesheet" type="text/css" href="/admin/swagger/resources/swagger-ui.css" />
+<style>
+    .download-url-wrapper,
+    .topbar {
+        display: none !important;
+    }
+</style>`
+                },
+                {
+                    layout: 'app'
+                }
+            );
+        }
+    });
+
+    server.route({
+        method: 'GET',
+        path: '/admin/legal',
+        async handler(request, h) {
+            return h.view(
+                'legal',
+                {
+                    pageTitle: 'Legal',
+                    menuLegal: true
+                },
+                {
+                    layout: 'app'
+                }
+            );
+        }
+    });
+
+    server.route({
+        method: 'GET',
+        path: '/admin/upgrade',
+        async handler(request, h) {
+            const isDO = getBoolean(readEnvValue('EENGINE_DOCEAN'));
+            const isScriptInstalled = getBoolean(readEnvValue('EENGINE_INSTALL_SCRIPT'));
+            const isRender = typeof readEnvValue('RENDER_SERVICE_SLUG') === 'string' && readEnvValue('RENDER_SERVICE_SLUG');
+            const isGeneral = !isDO && !isRender && !isScriptInstalled;
+
+            return h.view(
+                'upgrade',
+                {
+                    pageTitle: 'Upgrade',
+                    isDO,
+                    isRender,
+                    isScriptInstalled,
+                    isGeneral
+                },
+                {
+                    layout: 'app'
+                }
+            );
+        }
+    });
+}
+
+module.exports = init;

--- a/test/ui-routes-size-test.js
+++ b/test/ui-routes-size-test.js
@@ -16,7 +16,7 @@ const fs = require('fs');
 const pathlib = require('path');
 
 // Lower this after every extraction batch to the new `wc -l lib/routes-ui.js`.
-const BUDGET = 7813;
+const BUDGET = 7643;
 
 test('routes-ui.js stays within the size budget', () => {
     const filePath = pathlib.join(__dirname, '..', 'lib', 'routes-ui.js');


### PR DESCRIPTION
## What & why

Batch 4 of the `routes-ui.js` decomposition (tech-debt **A2**). Moves the dashboard and standalone info pages verbatim into a focused module.

**Stacked on #602** (batch 3). Base auto-retargets up the stack as earlier PRs merge.

## Change

- New `lib/ui-routes/dashboard-routes.js`: `GET /admin` (dashboard), `GET /admin/swagger`, `GET /admin/legal`, `GET /admin/upgrade` (verbatim).
- `getStats` and `ALLOWED_REDIS_LATENCY` were only used here - removed from `routes-ui.js` imports.
- Size ratchet lowered: `routes-ui.js` 7813 -> 7643.

## Verification

- Route-table snapshot unchanged (128 routes); ESLint + Prettier clean.
- Booted server: all four GET pages render 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)