### PR TITLE
refactor: extract account export routes (A2 batch 5)

### DIFF
--- a/lib/routes-ui.js
+++ b/lib/routes-ui.js
@@ -39,16 +39,7 @@ const { verifyOAuth2App } = require('./oauth/verify-app');
 const { autodetectImapSettings } = require('./autodetect-imap-settings');
 const getSecret = require('./get-secret');
 const os = require('os');
-const {
-    ADDRESS_STRATEGIES,
-    settingsSchema,
-    oauthCreateSchema,
-    oauthUpdateSchema,
-    accountIdSchema,
-    defaultAccountTypeSchema,
-    exportIdSchema
-} = require('./schemas');
-const fs = require('fs');
+const { ADDRESS_STRATEGIES, settingsSchema, oauthCreateSchema, oauthUpdateSchema, accountIdSchema, defaultAccountTypeSchema } = require('./schemas');
 const timezonesList = require('timezones-list').default;
 const { Client: ElasticSearch } = require('@elastic/elasticsearch');
 const { llmPreProcess } = require('./llm-pre-process');
@@ -68,6 +59,7 @@ const smtpTestRoutes = require('./ui-routes/smtp-test-routes');
 const unsubscribeRoutes = require('./ui-routes/unsubscribe-routes');
 const internalsRoutes = require('./ui-routes/internals-routes');
 const dashboardRoutes = require('./ui-routes/dashboard-routes');
+const exportRoutes = require('./ui-routes/export-routes');
 const {
     throwAsBoom,
     formatAccountData,
@@ -77,7 +69,6 @@ const {
     getExampleDocumentsPayloads,
     cachedTemplates
 } = require('./ui-routes/route-helpers');
-const { Export } = require('./export');
 const passkeys = require('./passkeys');
 const {
     generateRegistrationOptions,
@@ -455,6 +446,9 @@ function applyRoutes(server, call) {
     // Dashboard and standalone informational pages (swagger, legal, upgrade)
     dashboardRoutes({ server, call });
 
+    // Account data export routes
+    exportRoutes({ server });
+
     // Render-context booleans for the gmailService authMethod tab selector.
     // When `locked` is set the selector is shown but cannot be switched - the
     // authentication method is fixed once an app has been created.
@@ -480,202 +474,6 @@ function applyRoutes(server, call) {
         }
         return apps;
     }
-
-    // List exports for account
-    server.route({
-        method: 'GET',
-        path: '/admin/accounts/{account}/exports',
-        async handler(request) {
-            try {
-                return await Export.list(request.params.account, {
-                    page: request.query.page,
-                    pageSize: request.query.pageSize
-                });
-            } catch (err) {
-                request.logger.error({ msg: 'Failed to list exports', err, account: request.params.account });
-                throwAsBoom(err);
-            }
-        },
-        options: {
-            validate: {
-                options: {
-                    stripUnknown: true,
-                    abortEarly: false,
-                    convert: true
-                },
-                failAction,
-                params: Joi.object({
-                    account: Joi.string().max(256).required()
-                }),
-                query: Joi.object({
-                    page: Joi.number().integer().min(0).default(0),
-                    pageSize: Joi.number().integer().min(1).max(100).default(20)
-                })
-            }
-        }
-    });
-
-    // Get export status
-    server.route({
-        method: 'GET',
-        path: '/admin/accounts/{account}/export/{exportId}',
-        async handler(request) {
-            try {
-                const result = await Export.get(request.params.account, request.params.exportId);
-                if (!result) {
-                    throw Boom.notFound('Export not found');
-                }
-                return result;
-            } catch (err) {
-                request.logger.error({ msg: 'Failed to get export', err, account: request.params.account, exportId: request.params.exportId });
-                throwAsBoom(err);
-            }
-        },
-        options: {
-            validate: {
-                options: {
-                    stripUnknown: true,
-                    abortEarly: false,
-                    convert: true
-                },
-                failAction,
-                params: Joi.object({
-                    account: Joi.string().max(256).required(),
-                    exportId: exportIdSchema
-                })
-            }
-        }
-    });
-
-    // Create export
-    server.route({
-        method: 'POST',
-        path: '/admin/accounts/{account}/export',
-        async handler(request) {
-            try {
-                return await Export.create(request.params.account, {
-                    startDate: request.payload.startDate,
-                    endDate: request.payload.endDate,
-                    includeAttachments: request.payload.includeAttachments,
-                    folders: []
-                });
-            } catch (err) {
-                request.logger.error({ msg: 'Failed to create export', err, account: request.params.account });
-                throwAsBoom(err);
-            }
-        },
-        options: {
-            validate: {
-                options: {
-                    stripUnknown: true,
-                    abortEarly: false,
-                    convert: true
-                },
-                failAction,
-                params: Joi.object({
-                    account: Joi.string().max(256).required()
-                }),
-                payload: Joi.object({
-                    startDate: Joi.date().iso().required(),
-                    endDate: Joi.date().iso().required(),
-                    includeAttachments: Joi.boolean().default(false)
-                })
-            }
-        }
-    });
-
-    // Delete export
-    server.route({
-        method: 'DELETE',
-        path: '/admin/accounts/{account}/export/{exportId}',
-        async handler(request) {
-            try {
-                const deleted = await Export.delete(request.params.account, request.params.exportId);
-                if (!deleted) {
-                    throw Boom.notFound('Export not found');
-                }
-                return { deleted: true };
-            } catch (err) {
-                request.logger.error({ msg: 'Failed to delete export', err, account: request.params.account, exportId: request.params.exportId });
-                throwAsBoom(err);
-            }
-        },
-        options: {
-            validate: {
-                options: {
-                    stripUnknown: true,
-                    abortEarly: false,
-                    convert: true
-                },
-                failAction,
-                params: Joi.object({
-                    account: Joi.string().max(256).required(),
-                    exportId: exportIdSchema
-                })
-            }
-        }
-    });
-
-    // Download export file
-    server.route({
-        method: 'GET',
-        path: '/admin/accounts/{account}/export/{exportId}/download',
-        async handler(request, h) {
-            try {
-                const { account, exportId } = request.params;
-                const fileInfo = await Export.getFile(account, exportId);
-                if (!fileInfo) {
-                    throw Boom.notFound('Export not found');
-                }
-
-                const fileReadStream = fs.createReadStream(fileInfo.filePath);
-                let stream = fileReadStream;
-
-                stream.on('error', err => {
-                    request.logger.error({ msg: 'Export download stream error', exportId, err });
-                });
-
-                // Decrypt file if encrypted
-                if (fileInfo.isEncrypted) {
-                    const secret = await getSecret();
-                    if (!secret) {
-                        fileReadStream.destroy();
-                        throw Boom.serverUnavailable('Encryption secret not available for decryption');
-                    }
-                    const { createDecryptStream } = require('./stream-encrypt');
-                    const decryptStream = await createDecryptStream(secret);
-                    decryptStream.on('error', err => {
-                        request.logger.error({ msg: 'Export decryption error', exportId, err });
-                        fileReadStream.destroy();
-                    });
-                    stream = fileReadStream.pipe(decryptStream);
-                }
-
-                return h
-                    .response(stream)
-                    .type('application/gzip')
-                    .header('Content-Disposition', `attachment; filename="${fileInfo.filename}"`)
-                    .header('Content-Encoding', 'identity');
-            } catch (err) {
-                request.logger.error({ msg: 'Failed to download export', err, account: request.params.account, exportId: request.params.exportId });
-                throwAsBoom(err);
-            }
-        },
-        options: {
-            validate: {
-                options: {
-                    stripUnknown: true,
-                    abortEarly: false,
-                    convert: true
-                },
-                failAction,
-                params: Joi.object({
-                    account: Joi.string().max(256).required(),
-                    exportId: exportIdSchema
-                })
-            }
-        }
-    });
 
     const getDefaultPrompt = async () =>
         await call({

--- a/lib/ui-routes/export-routes.js
+++ b/lib/ui-routes/export-routes.js
@@ -1,0 +1,217 @@
+'use strict';
+
+// Admin UI routes for account data exports (the Exports tab on an account page): list,
+// status, create, delete, and download. Extracted verbatim from lib/routes-ui.js. These
+// are session-authenticated JSON/file endpoints backed by the Export class.
+
+const Joi = require('joi');
+const Boom = require('@hapi/boom');
+const fs = require('fs');
+
+const { Export } = require('../export');
+const getSecret = require('../get-secret');
+const { failAction } = require('../tools');
+const { exportIdSchema } = require('../schemas');
+const { throwAsBoom } = require('./route-helpers');
+
+function init(args) {
+    const { server } = args;
+
+    // List exports for account
+    server.route({
+        method: 'GET',
+        path: '/admin/accounts/{account}/exports',
+        async handler(request) {
+            try {
+                return await Export.list(request.params.account, {
+                    page: request.query.page,
+                    pageSize: request.query.pageSize
+                });
+            } catch (err) {
+                request.logger.error({ msg: 'Failed to list exports', err, account: request.params.account });
+                throwAsBoom(err);
+            }
+        },
+        options: {
+            validate: {
+                options: {
+                    stripUnknown: true,
+                    abortEarly: false,
+                    convert: true
+                },
+                failAction,
+                params: Joi.object({
+                    account: Joi.string().max(256).required()
+                }),
+                query: Joi.object({
+                    page: Joi.number().integer().min(0).default(0),
+                    pageSize: Joi.number().integer().min(1).max(100).default(20)
+                })
+            }
+        }
+    });
+
+    // Get export status
+    server.route({
+        method: 'GET',
+        path: '/admin/accounts/{account}/export/{exportId}',
+        async handler(request) {
+            try {
+                const result = await Export.get(request.params.account, request.params.exportId);
+                if (!result) {
+                    throw Boom.notFound('Export not found');
+                }
+                return result;
+            } catch (err) {
+                request.logger.error({ msg: 'Failed to get export', err, account: request.params.account, exportId: request.params.exportId });
+                throwAsBoom(err);
+            }
+        },
+        options: {
+            validate: {
+                options: {
+                    stripUnknown: true,
+                    abortEarly: false,
+                    convert: true
+                },
+                failAction,
+                params: Joi.object({
+                    account: Joi.string().max(256).required(),
+                    exportId: exportIdSchema
+                })
+            }
+        }
+    });
+
+    // Create export
+    server.route({
+        method: 'POST',
+        path: '/admin/accounts/{account}/export',
+        async handler(request) {
+            try {
+                return await Export.create(request.params.account, {
+                    startDate: request.payload.startDate,
+                    endDate: request.payload.endDate,
+                    includeAttachments: request.payload.includeAttachments,
+                    folders: []
+                });
+            } catch (err) {
+                request.logger.error({ msg: 'Failed to create export', err, account: request.params.account });
+                throwAsBoom(err);
+            }
+        },
+        options: {
+            validate: {
+                options: {
+                    stripUnknown: true,
+                    abortEarly: false,
+                    convert: true
+                },
+                failAction,
+                params: Joi.object({
+                    account: Joi.string().max(256).required()
+                }),
+                payload: Joi.object({
+                    startDate: Joi.date().iso().required(),
+                    endDate: Joi.date().iso().required(),
+                    includeAttachments: Joi.boolean().default(false)
+                })
+            }
+        }
+    });
+
+    // Delete export
+    server.route({
+        method: 'DELETE',
+        path: '/admin/accounts/{account}/export/{exportId}',
+        async handler(request) {
+            try {
+                const deleted = await Export.delete(request.params.account, request.params.exportId);
+                if (!deleted) {
+                    throw Boom.notFound('Export not found');
+                }
+                return { deleted: true };
+            } catch (err) {
+                request.logger.error({ msg: 'Failed to delete export', err, account: request.params.account, exportId: request.params.exportId });
+                throwAsBoom(err);
+            }
+        },
+        options: {
+            validate: {
+                options: {
+                    stripUnknown: true,
+                    abortEarly: false,
+                    convert: true
+                },
+                failAction,
+                params: Joi.object({
+                    account: Joi.string().max(256).required(),
+                    exportId: exportIdSchema
+                })
+            }
+        }
+    });
+
+    // Download export file
+    server.route({
+        method: 'GET',
+        path: '/admin/accounts/{account}/export/{exportId}/download',
+        async handler(request, h) {
+            try {
+                const { account, exportId } = request.params;
+                const fileInfo = await Export.getFile(account, exportId);
+                if (!fileInfo) {
+                    throw Boom.notFound('Export not found');
+                }
+
+                const fileReadStream = fs.createReadStream(fileInfo.filePath);
+                let stream = fileReadStream;
+
+                stream.on('error', err => {
+                    request.logger.error({ msg: 'Export download stream error', exportId, err });
+                });
+
+                // Decrypt file if encrypted
+                if (fileInfo.isEncrypted) {
+                    const secret = await getSecret();
+                    if (!secret) {
+                        fileReadStream.destroy();
+                        throw Boom.serverUnavailable('Encryption secret not available for decryption');
+                    }
+                    const { createDecryptStream } = require('../stream-encrypt');
+                    const decryptStream = await createDecryptStream(secret);
+                    decryptStream.on('error', err => {
+                        request.logger.error({ msg: 'Export decryption error', exportId, err });
+                        fileReadStream.destroy();
+                    });
+                    stream = fileReadStream.pipe(decryptStream);
+                }
+
+                return h
+                    .response(stream)
+                    .type('application/gzip')
+                    .header('Content-Disposition', `attachment; filename="${fileInfo.filename}"`)
+                    .header('Content-Encoding', 'identity');
+            } catch (err) {
+                request.logger.error({ msg: 'Failed to download export', err, account: request.params.account, exportId: request.params.exportId });
+                throwAsBoom(err);
+            }
+        },
+        options: {
+            validate: {
+                options: {
+                    stripUnknown: true,
+                    abortEarly: false,
+                    convert: true
+                },
+                failAction,
+                params: Joi.object({
+                    account: Joi.string().max(256).required(),
+                    exportId: exportIdSchema
+                })
+            }
+        }
+    });
+}
+
+module.exports = init;

--- a/test/ui-routes-size-test.js
+++ b/test/ui-routes-size-test.js
@@ -16,7 +16,7 @@ const fs = require('fs');
 const pathlib = require('path');
 
 // Lower this after every extraction batch to the new `wc -l lib/routes-ui.js`.
-const BUDGET = 7643;
+const BUDGET = 7448;
 
 test('routes-ui.js stays within the size budget', () => {
     const filePath = pathlib.join(__dirname, '..', 'lib', 'routes-ui.js');


### PR DESCRIPTION
Batch 5 of the routes-ui.js decomposition (tech-debt A2). Moves the five `/admin/accounts/{account}/export*` routes verbatim into `lib/ui-routes/export-routes.js` (list, status, create, delete, download).

- New `lib/ui-routes/export-routes.js`; `throwAsBoom` imported from route-helpers; inline `stream-encrypt` require path-adjusted.
- `Export`, `exportIdSchema`, and `fs` were only used here - removed from routes-ui.js imports.
- routes-ui.js 7643 -> 7441; size ratchet lowered.
- Route-table snapshot unchanged; ESLint + Prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)