### PR TITLE
fix: constant-time Graph clientState check and unsubscribe email escaping

### DIFF
--- a/test/e2e/helpers/bootstrap.js
+++ b/test/e2e/helpers/bootstrap.js
@@ -1,0 +1,66 @@
+'use strict';
+
+// Idempotent admin-UI bootstrap helpers for the e2e suite. Every spec shares one booted
+// EmailEngine instance and the isolated Redis db 14 (see playwright.config.js), so these must
+// tolerate an instance another spec has already bootstrapped: set the first admin password on a
+// fresh instance, otherwise log in; activate a trial only when the instance is not yet licensed.
+
+const { expect } = require('@playwright/test');
+
+// Log in through the admin sign-in form. The set-password flow stores an empty username, so the
+// server's username check is bypassed and any non-empty username works.
+async function loginAsAdmin(page, password) {
+    await page.fill('#loginUsername', 'admin');
+    await page.fill('#loginPassword', password);
+    await page.click('form[action="/admin/login"] button[type="submit"]');
+    await page.waitForURL(url => !url.pathname.startsWith('/admin/login'), { timeout: 15000 });
+}
+
+// Guarantee the browser context holds an authenticated admin session on return.
+async function ensureAdminSession(page, password) {
+    await page.goto('/admin');
+    if (page.url().includes('/admin/login')) {
+        // Auth already enabled by an earlier spec - just log in.
+        await loginAsAdmin(page, password);
+        return;
+    }
+
+    // Fresh instance: setting the first password enables auth and auto-logs-in.
+    await page.goto('/admin/account/password');
+    await page.fill('#password', password);
+    await page.fill('#password2', password);
+    await page.click('button[type="submit"]');
+    await page.waitForLoadState();
+
+    // Confirm we actually hold a session; log in explicitly if the auto-login did not take.
+    await page.goto('/admin');
+    if (page.url().includes('/admin/login')) {
+        await loginAsAdmin(page, password);
+    }
+}
+
+// Activate a 14-day trial if the instance is not already licensed. The "Start a 14-day trial"
+// button is only rendered while unlicensed, so its absence means we are done.
+async function ensureTrial(page) {
+    await page.goto('/admin');
+    const trialBtn = page.locator('#start-trial-btn');
+    if (await trialBtn.count()) {
+        await trialBtn.click();
+        await expect(trialBtn).toHaveCount(0, { timeout: 60000 });
+    }
+}
+
+// Create a full-access REST API token via the admin UI and return the 64-hex secret.
+async function createApiToken(page, description = 'e2e token') {
+    await page.goto('/admin/tokens/new');
+    await page.fill('#description', description);
+    await page.check('#scopesAll'); // data-scope="*" -> full access
+    await page.click('#token-form button[type="submit"]');
+
+    // The token is revealed once in the modal input #showTokenValue.
+    const tokenInput = page.locator('#showTokenValue');
+    await expect(tokenInput).not.toHaveValue('', { timeout: 20000 });
+    return tokenInput.inputValue();
+}
+
+module.exports = { ensureAdminSession, ensureTrial, createApiToken };

--- a/test/e2e/hosted-form.spec.js
+++ b/test/e2e/hosted-form.spec.js
@@ -1,0 +1,123 @@
+'use strict';
+
+// End-to-end: add an IMAP email account through the HOSTED AUTHENTICATION FORM - the signed
+// /accounts/new flow an operator hands to a user - exercising the IMAP path (not OAuth2):
+//
+//   1. bootstrap the shared instance (admin session, trial, API token)  -> admin UI
+//   2. provision an Ethereal account (nodemailer test account)          -> nodemailer
+//   3. generate a signed hosted-auth URL                                -> REST API
+//   4. drive the hosted form: choose IMAP, enter email/password, then   -> browser
+//      the IMAP + SMTP server details, and submit
+//   5. confirm the account was created and reaches "connected"          -> REST API
+//
+// This shares the Playwright webServer and Redis db 14 with the other specs, so the bootstrap is
+// idempotent (helpers/bootstrap.js) and the account id is unique to this spec.
+//
+// Run once:  npm run test:e2e:install
+// Run suite: npm run test:e2e
+
+const { test, expect, request } = require('@playwright/test');
+const { createUsableTestAccount } = require('./helpers/ethereal');
+const { ensureAdminSession, ensureTrial, createApiToken } = require('./helpers/bootstrap');
+
+const PORT = 7099;
+const BASE_URL = `http://127.0.0.1:${PORT}`;
+const ADMIN_PASSWORD = 'E2e-Test-Password-123!';
+const ACCOUNT_ID = 'e2e-hosted-imap';
+
+test('hosted auth form: add an IMAP account (Ethereal) and reach connected', async ({ page }) => {
+    let token;
+
+    await test.step('bootstrap: admin session, trial, API token', async () => {
+        await ensureAdminSession(page, ADMIN_PASSWORD);
+        await ensureTrial(page);
+        token = await createApiToken(page, 'e2e hosted-form token');
+        expect(token).toMatch(/^[0-9a-f]{64}$/);
+    });
+
+    const acct = await createUsableTestAccount();
+
+    const api = await request.newContext({
+        baseURL: BASE_URL,
+        extraHTTPHeaders: { Authorization: `Bearer ${token}` }
+    });
+
+    try {
+        let formUrl;
+        await test.step('generate the hosted authentication URL', async () => {
+            const res = await api.post('/v1/authentication/form', {
+                data: {
+                    account: ACCOUNT_ID,
+                    name: 'E2E Hosted IMAP',
+                    email: acct.user,
+                    redirectUrl: `${BASE_URL}/admin`
+                }
+            });
+            expect(res.ok(), `POST /v1/authentication/form -> ${res.status()} ${await res.text()}`).toBeTruthy();
+            const body = await res.json();
+            // The URL is generated against the public serviceUrl (config/e2e.toml), so reuse its
+            // signed query string (data/sig/type) against the local test server - the signed blob
+            // is host-independent.
+            formUrl = `${BASE_URL}/accounts/new${new URL(body.url).search}`;
+        });
+
+        await test.step('hosted form: choose IMAP and enter email + password', async () => {
+            await page.goto(formUrl);
+            // A fresh instance has no OAuth2 apps, so the URL carries type=imap and lands directly
+            // on the email/password form. If the provider-selection screen shows (e.g. another spec
+            // added an OAuth2 app to the shared instance), pick the Standard IMAP provider. Anchor on
+            // the form's action + hidden type field rather than the localized button text.
+            const imapBtn = page.locator('form[action="/accounts/new"]:has(input[name="type"][value="imap"]) button[type="submit"]');
+            if (await imapBtn.count()) {
+                await imapBtn.click();
+            }
+            await page.fill('#name', 'E2E Hosted IMAP');
+            await page.fill('#email', acct.user);
+            await page.fill('#password', acct.pass);
+            await page.click('form[action="/accounts/new/imap"] button[type="submit"]');
+        });
+
+        await test.step('hosted form: enter IMAP + SMTP server details and submit', async () => {
+            await expect(page.locator('#imap_host')).toBeVisible({ timeout: 30000 });
+
+            // Autodetect does not know ethereal.email, so set every field explicitly.
+            await page.fill('#imap_auth_user', acct.user);
+            await page.fill('#imap_auth_pass', acct.pass);
+            await page.fill('#imap_host', acct.imap.host);
+            await page.fill('#imap_port', String(acct.imap.port));
+            await page.locator('#imap_secure').setChecked(!!acct.imap.secure);
+
+            await page.fill('#smtp_auth_user', acct.user);
+            await page.fill('#smtp_auth_pass', acct.pass);
+            await page.fill('#smtp_host', acct.smtp.host);
+            await page.fill('#smtp_port', String(acct.smtp.port));
+            await page.locator('#smtp_secure').setChecked(!!acct.smtp.secure);
+
+            // Submit via "Skip verification" (in the split-button dropdown): a deterministic submit
+            // with no live connection test. Real connectivity is proven by the connected poll below.
+            await page.click('#submit-settings-btn-down');
+            await page.click('#submit-wo-testing');
+
+            // The server creates the account and renders redirect.hbs (a link only). Its continue
+            // link points at redirectUrl?account=<id>&state=... - proof the account was created.
+            await expect(page.locator(`a[href*="account=${ACCOUNT_ID}"]`)).toBeVisible({ timeout: 30000 });
+        });
+
+        await test.step('account exists and reaches connected', async () => {
+            await expect
+                .poll(
+                    async () => {
+                        const res = await api.get(`/v1/account/${ACCOUNT_ID}`);
+                        if (!res.ok()) {
+                            return `http-${res.status()}`;
+                        }
+                        return (await res.json()).state;
+                    },
+                    { timeout: 120000, intervals: [1000, 2000, 3000] }
+                )
+                .toBe('connected');
+        });
+    } finally {
+        await api.dispose();
+    }
+});

--- a/views/unsubscribe.hbs
+++ b/views/unsubscribe.hbs
@@ -18,8 +18,8 @@
                 </button>
             </div>
             <div class="modal-body">
-                {{_ "Are you sure you want to re-subscribe your email address <em>%s</em>?" templateLocale values.email
-                }}
+                {{_ "Are you sure you want to re-subscribe your email address <em>%s</em>?" templateLocale
+                (escapeHtml values.email) }}
             </div>
             <div class="modal-footer">
                 <form method="post" action="/unsubscribe/address">
@@ -53,7 +53,7 @@
 
 <h1 class="h4 text-gray-900 mb-4">{{_ "Subscription resumed" templateLocale }}</h1>
 
-<p>{{_ "Your email address <em>%s</em> was re-subscribed." templateLocale values.email}}</p>
+<p>{{_ "Your email address <em>%s</em> was re-subscribed." templateLocale (escapeHtml values.email)}}</p>
 
 {{else}}
 

--- a/workers/api.js
+++ b/workers/api.js
@@ -513,6 +513,11 @@ const init = async () => {
         return new handlebars.SafeString(translated);
     });
 
+    // HTML-escape a value for safe interpolation into an otherwise-unescaped context - e.g. a
+    // dynamic `%s` argument to the SafeString-returning `_` helper. Returns a plain string so
+    // the surrounding markup stays live while the value itself is entity-escaped.
+    handlebars.registerHelper('escapeHtml', value => handlebars.escapeExpression(value));
+
     handlebars.registerHelper('isodate', time => new Date(Number(time)).toISOString());
 
     handlebars.registerHelper('ngettext', (msgid, plural, count) => util.format(gt.ngettext(msgid, plural, count), count));
@@ -1873,14 +1878,16 @@ Include your token in requests using one of these methods:
 
             for (let entry of (request.payload && request.payload.value) || []) {
                 // enumerate and queue all entries
-                if (entry.subscriptionId !== outlookSubscription.id || entry.clientState !== outlookSubscription.clientState) {
+                const subscriptionIdMatch = entry.subscriptionId === outlookSubscription.id;
+                const clientStateMatch = constantTimeEqual(entry.clientState, outlookSubscription.clientState);
+                if (!subscriptionIdMatch || !clientStateMatch) {
                     // Security: Log webhook validation failures - could indicate spoofed notifications
                     request.logger.warn({
                         msg: 'Webhook validation failed - potential security issue',
                         securityEvent: 'webhook_validation_failure',
                         account: request.query.account,
-                        subscriptionIdMatch: entry.subscriptionId === outlookSubscription.id,
-                        clientStateMatch: entry.clientState === outlookSubscription.clientState,
+                        subscriptionIdMatch,
+                        clientStateMatch,
                         receivedSubscriptionId: entry.subscriptionId,
                         changeType: entry.changeType,
                         resource: entry.resource
@@ -1977,14 +1984,16 @@ Include your token in requests using one of these methods:
                 });
 
                 // enumerate and queue all entries
-                if (entry.subscriptionId !== outlookSubscription.id || entry.clientState !== outlookSubscription.clientState) {
+                const subscriptionIdMatch = entry.subscriptionId === outlookSubscription.id;
+                const clientStateMatch = constantTimeEqual(entry.clientState, outlookSubscription.clientState);
+                if (!subscriptionIdMatch || !clientStateMatch) {
                     // Security: Log lifecycle webhook validation failures - could indicate spoofed notifications
                     request.logger.warn({
                         msg: 'Lifecycle webhook validation failed - potential security issue',
                         securityEvent: 'lifecycle_webhook_validation_failure',
                         account: request.query.account,
-                        subscriptionIdMatch: entry.subscriptionId === outlookSubscription.id,
-                        clientStateMatch: entry.clientState === outlookSubscription.clientState,
+                        subscriptionIdMatch,
+                        clientStateMatch,
                         receivedSubscriptionId: entry.subscriptionId,
                         lifecycleEvent: entry.lifecycleEvent
                     });


### PR DESCRIPTION
Follow-ups from the security review of the changes since v2.72.2 - two low-severity, same-class gaps that batch missed, plus e2e coverage for the hosted auth form.

## Fixes
- **MS Graph webhook `clientState`** (`workers/api.js`): compare the shared secret with `constantTimeEqual` in the `/oauth/msg` and `/oauth/msg/lifecycle` handlers (was a timing-unsafe `!==`). The `subscriptionId`/`clientState` comparisons are hoisted into locals reused by the gate and the validation-failure log.
- **Unsubscribe page XSS parity** (`workers/api.js`, `views/unsubscribe.hbs`): add an `escapeHtml` Handlebars helper and wrap the recipient email fed to the SafeString-returning gettext helper, so it is entity-escaped like the `value="{{values.email}}"` field already on that page. The translatable message id is unchanged.

## Test
- New Playwright e2e spec (`test/e2e/hosted-form.spec.js`) that drives the hosted authentication form's IMAP path with Ethereal credentials (nodemailer test account) and asserts the account reaches `connected`. Adds idempotent admin-UI bootstrap helpers (`test/e2e/helpers/bootstrap.js`) so it coexists with the happy-path spec on the shared e2e instance.

## Verification
- `npm run test:unit` - 1259 passed, 0 failed
- `npm run test:e2e` - 2 passed (happy-path + new hosted-form spec)
- /security-review - no newly-introduced vulnerabilities

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015bNZXFKjpBip2qH3CDsH8H
