### PR TITLE
feat: add expected OAuth identity constraint

### DIFF
--- a/lib/api-routes/account-routes.js
+++ b/lib/api-routes/account-routes.js
@@ -1368,6 +1368,7 @@ async function init(args) {
                     account: request.payload.account,
                     name: request.payload.name,
                     email: request.payload.email,
+                    expectedEmail: request.payload.expectedEmail,
                     syncFrom: request.payload.syncFrom,
                     notifyFrom: request.payload.notifyFrom,
                     subconnections: request.payload.subconnections,
@@ -1465,6 +1466,12 @@ async function init(args) {
                         .email()
                         .example('user@example.com')
                         .description('Specifies the default email address for this account. Users can change it if needed.'),
+
+                    expectedEmail: Joi.string()
+                        .empty('')
+                        .email()
+                        .example('user@example.com')
+                        .description('Rejects OAuth authorization when the provider identity does not match this email address.'),
 
                     delegated: Joi.boolean()
                         .empty('')

--- a/lib/oauth/expected-identity.js
+++ b/lib/oauth/expected-identity.js
@@ -1,0 +1,16 @@
+'use strict';
+
+function normalizeEmail(value) {
+    return typeof value === 'string' ? value.trim().toLowerCase() : '';
+}
+
+function matchesExpectedOAuthIdentity(expectedEmail, providerIdentities) {
+    const expected = normalizeEmail(expectedEmail);
+    if (!expected) {
+        return false;
+    }
+
+    return providerIdentities.some(identity => normalizeEmail(identity) === expected);
+}
+
+module.exports = { matchesExpectedOAuthIdentity };

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -1813,6 +1813,7 @@ MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEV3QUiYsp13nD9suD1/ZkEXnuMoSg
                           account: opts.account,
                           name: opts.name,
                           email: opts.email,
+                          expectedEmail: opts.expectedEmail,
                           syncFrom: (opts.syncFrom && opts.syncFrom.toISOString()) || null,
                           notifyFrom: (opts.notifyFrom && opts.notifyFrom.toISOString()) || null,
                           subconnections: opts.subconnections && opts.subconnections.length ? opts.subconnections : null,

--- a/lib/ui-routes/account-routes.js
+++ b/lib/ui-routes/account-routes.js
@@ -358,7 +358,7 @@ function init(args) {
 
             accountData.notifyFrom = data.notifyFrom || new Date().toISOString();
 
-            for (let key of ['redirectUrl', 'n', 't']) {
+            for (let key of ['redirectUrl', 'expectedEmail', 'n', 't']) {
                 if (!accountData._meta) {
                     accountData._meta = {};
                 }

--- a/test/fixtures/openapi-golden.json
+++ b/test/fixtures/openapi-golden.json
@@ -6148,6 +6148,14 @@
               "email": true
             }
           },
+          "expectedEmail": {
+            "type": "string",
+            "description": "Rejects OAuth authorization when the provider identity does not match this email address.",
+            "example": "user@example.com",
+            "x-format": {
+              "email": true
+            }
+          },
           "delegated": {
             "type": "boolean",
             "description": "If true, configures this account as a shared mailbox. Currently supported by MS365 OAuth2 accounts",

--- a/test/oauth-expected-identity-test.js
+++ b/test/oauth-expected-identity-test.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert').strict;
+
+const { matchesExpectedOAuthIdentity } = require('../lib/oauth/expected-identity');
+
+test('matchesExpectedOAuthIdentity', async t => {
+    await t.test('matches provider identities case-insensitively', () => {
+        assert.equal(matchesExpectedOAuthIdentity(' Owner@Example.com ', ['owner@example.com']), true);
+    });
+
+    await t.test('accepts a secondary provider identity such as a Microsoft UPN', () => {
+        assert.equal(matchesExpectedOAuthIdentity('principal@example.com', ['mail-alias@example.com', 'principal@example.com']), true);
+    });
+
+    await t.test('rejects an identity that was not returned by the provider', () => {
+        assert.equal(matchesExpectedOAuthIdentity('hint@example.com', ['actual@example.com']), false);
+    });
+
+    await t.test('rejects empty expected or provider identities', () => {
+        assert.equal(matchesExpectedOAuthIdentity('', ['actual@example.com']), false);
+        assert.equal(matchesExpectedOAuthIdentity('owner@example.com', [null, undefined, '']), false);
+    });
+});

--- a/test/tools-test.js
+++ b/test/tools-test.js
@@ -191,13 +191,14 @@ test('Tools utility tests', async t => {
 
     await t.test('getSignedFormDataSync() data can be decoded', async () => {
         const secret = 'test-secret';
-        const opts = { account: 'my-account', name: 'John Doe' };
+        const opts = { account: 'my-account', name: 'John Doe', expectedEmail: 'owner@example.com' };
 
         const result = tools.getSignedFormDataSync(secret, opts);
         const decoded = JSON.parse(Buffer.from(result.data, 'base64url').toString());
 
         assert.strictEqual(decoded.account, 'my-account');
         assert.strictEqual(decoded.name, 'John Doe');
+        assert.strictEqual(decoded.expectedEmail, 'owner@example.com');
     });
 
     await t.test('getSignedFormDataSync() filters empty values', async () => {

--- a/workers/api.js
+++ b/workers/api.js
@@ -63,6 +63,7 @@ const pathlib = require('path');
 const crypto = require('crypto');
 const { registeredPublishers, openChangeStream } = require('../lib/response-stream');
 const { oauth2Apps } = require('../lib/oauth2-apps');
+const { matchesExpectedOAuthIdentity } = require('../lib/oauth/expected-identity');
 
 const handlebars = require('handlebars');
 const AuthBearer = require('hapi-auth-bearer-token');
@@ -2063,6 +2064,8 @@ const init = async () => {
             }
 
             const oAuth2Client = await oauth2Apps.getClient(oauth2App.id);
+            // Only provider responses are identity evidence. accountData contains caller-supplied hints.
+            const providerIdentities = [];
 
             // `app.provider` is for example "gmail", `provider` is oauth2 app id
             switch (oauth2App.provider) {
@@ -2188,6 +2191,7 @@ const init = async () => {
                         throw error;
                     }
 
+                    providerIdentities.push(userEmail);
                     accountData.email = isEmail(userEmail) ? userEmail : accountData.email;
 
                     const defaultScopes = (oauth2App.baseScopes && GMAIL_SCOPES[oauth2App.baseScopes]) || GMAIL_SCOPES.imap;
@@ -2308,6 +2312,8 @@ const init = async () => {
                         throw error;
                     }
 
+                    providerIdentities.push(userInfo.email, userInfo.username);
+
                     if (accountData.oauth2 && accountData.oauth2.auth && accountData.oauth2.auth.delegatedUser) {
                         // Delegated user (shared mailbox) specified in oauth2.auth.delegatedUser
                         authData.delegatedUser = accountData.oauth2.auth.delegatedUser;
@@ -2369,6 +2375,7 @@ const init = async () => {
                         throw error;
                     }
 
+                    providerIdentities.push(profileRes.email);
                     accountData.name = accountData.name || profileRes.name || '';
                     accountData.email = isEmail(profileRes.email) ? profileRes.email : accountData.email;
 
@@ -2396,6 +2403,37 @@ const init = async () => {
                 default: {
                     throw new Error('Unknown OAuth2 provider');
                 }
+            }
+
+            if (accountMeta.expectedEmail && !matchesExpectedOAuthIdentity(accountMeta.expectedEmail, providerIdentities)) {
+                request.logger.warn({
+                    msg: 'OAuth identity did not match the expected email address',
+                    account: accountData.account,
+                    provider: oauth2App.provider
+                });
+
+                if (redirectUrl) {
+                    const serviceUrl = await settings.get('serviceUrl');
+                    const url = new URL(redirectUrl, serviceUrl);
+                    if (accountData.account) {
+                        url.searchParams.set('account', accountData.account);
+                    }
+                    url.searchParams.set('error', 'account_identity_mismatch');
+                    url.searchParams.set('error_description', 'Authenticated account does not match the expected email address');
+
+                    return h.view(
+                        'redirect',
+                        {
+                            pageTitleFull: request.app.gt.gettext('Email Account Setup'),
+                            httpRedirectUrl: url.href
+                        },
+                        {
+                            layout: 'public'
+                        }
+                    );
+                }
+
+                throw Boom.badRequest('Authenticated account does not match the expected email address');
             }
 
             if ('delegated' in accountData) {


### PR DESCRIPTION
## Problem

Hosted OAuth form consumers can reconnect an existing EmailEngine account, but they cannot constrain which provider identity is allowed to complete that reconnect. If the person completing the consent flow selects a different Google or Microsoft account, the callback can persist the new tokens before the integrating application has a chance to reject the mismatch.

This is especially risky for applications where EmailEngine accounts have an owner or where a delegated/shared mailbox must stay attached to the same authenticated principal.

GitHub Issues are disabled for this repository, so the proposal context is included here.

## Solution

Add an optional `expectedEmail` field to `POST /v1/authentication/form`.

- The value is included in the signed hosted-form payload and carried through OAuth metadata.
- Gmail, Microsoft and Mail.ru callbacks compare it case-insensitively with identities returned by the provider.
- Microsoft accepts both the mailbox email and user principal name because either may be the stable identity for a tenant.
- A mismatch returns `account_identity_mismatch` through the configured redirect, or HTTP 400 when no redirect is present.
- The check runs before `Account.create()`, so existing credentials are not overwritten on mismatch.

The constraint is optional, so existing callers and hosted-form behavior remain unchanged.

## Trust boundary

Only values returned by the OAuth provider are treated as identity evidence. Caller-controlled account hints and delegated mailbox fields are deliberately excluded from the comparison. The warning log records the account and provider but not either email address.

This is an opt-in integrity constraint for an already authenticated EmailEngine API caller; it is not intended to replace API authorization.

## Testing

- `npm run lint`
- `NODE_ENV=test node --test --test-timeout=180000 test/oauth-expected-identity-test.js test/tools-test.js test/openapi-golden-test.js test/openapi-test.js test/api-routes-table-test.js test/ui-routes-table-test.js test/parse-signed-form-data-test.js` (130 passed)
- `npm run test:unit` ran 1,865 tests locally: 1,856 passed, with no assertion failures in the changed areas. The command exited non-zero because the unchanged `account-revoke-on-delete-test.js` timed out after its skipped Gmail test and the runner then cancelled eight unchanged webhook tests.
