### PR TITLE
feat(accounts): pin an account to an expected email identity

### DIFF
--- a/lib/account.js
+++ b/lib/account.js
@@ -349,6 +349,13 @@ class Account {
                     }
                     break;
 
+                case 'expectedEmail':
+                    // '' is the cleared marker written by serializeAccountData - report it as unset.
+                    if (accountData[key]) {
+                        result[key] = accountData[key];
+                    }
+                    break;
+
                 case 'path':
                     if (!accountData[key] || !accountData[key].length) {
                         break;
@@ -651,6 +658,17 @@ class Account {
                     }
                     break;
 
+                case 'expectedEmail':
+                    // Clearable, so it cannot ride the default branch: that drops nulls, and hmset only
+                    // ever adds keys, which would leave an identity pin settable but never removable.
+                    // Follows the same convention as `copy` above - null serializes to the empty marker
+                    // and unserialize treats it as unset - rather than adding a per-field delete to
+                    // persistUpdate.
+                    if (typeof accountData[key] === 'string' || accountData[key] === null) {
+                        result[key] = accountData[key] || '';
+                    }
+                    break;
+
                 default:
                     if (typeof accountData[key] !== 'undefined' && accountData[key] !== null && typeof accountData[key].toString === 'function') {
                         result[key] = accountData[key].toString();
@@ -840,7 +858,15 @@ class Account {
             mergeObjects(accountData[subKey], oldAccountData[subKey]);
         }
 
-        let pipeline = this.redis.multi().hmset(this.getAccountKey(), this.serializeAccountData(accountData));
+        // An update whose payload serializes to nothing - an empty request, say - must not reach hmset:
+        // Redis rejects a write with no field/value pairs outright ("wrong number of arguments"), which
+        // surfaced as a 500 on a perfectly valid request.
+        const updatedFields = this.serializeAccountData(accountData);
+
+        let pipeline = this.redis.multi();
+        if (Object.keys(updatedFields).length) {
+            pipeline = pipeline.hmset(this.getAccountKey(), updatedFields);
+        }
 
         if (addProvider && !LEGACY_KEYS.includes(addProvider)) {
             pipeline = pipeline.sadd(`${REDIS_PREFIX}oapp:a:${addProvider}`, this.account);
@@ -880,15 +906,13 @@ class Account {
             }
         }
 
-        let [[err, result]] = await pipeline.exec();
-        if (err) {
-            throw err;
-        }
-
-        if (!result || result !== 'OK') {
-            let message = 'Something went wrong';
-            let error = Boom.boomify(new Error(message), { statusCode: 500 });
-            throw error;
+        // Surface the first failing reply. Checked by scanning rather than by reading a fixed index: the
+        // hmset is now conditional, so a positional read would silently start asserting against whichever
+        // command happened to be queued first.
+        for (let [err] of (await pipeline.exec()) || []) {
+            if (err) {
+                throw err;
+            }
         }
 
         return oldAccountData;

--- a/lib/account/expected-identity.js
+++ b/lib/account/expected-identity.js
@@ -1,0 +1,111 @@
+'use strict';
+
+const { REDIS_PREFIX } = require('../consts');
+
+// An account can carry an expected identity: the address that must own it, set by an authenticated API
+// caller through `expectedEmail` on POST /v1/authentication/form, POST /v1/account or
+// PUT /v1/account/{account}. Every interactive setup checks it before writing credentials.
+//
+// How strong that is depends on the arm, and the difference is not cosmetic. On OAuth2 the provider
+// vouches for the identity, so the pin genuinely stops someone binding a different mailbox. On IMAP the
+// only evidence is what was typed into the form: the submitted address is checked, but the credentials
+// beside it are a separate field, so a hand-crafted POST can still register the pinned address against a
+// mailbox it does not own. The IMAP guarantee is therefore "the account is registered under the expected
+// address", not "the account holds that mailbox". Do not restate it more strongly than that.
+//
+// Everything the two arms must agree on lives here - where the expectation is read from, which one wins,
+// what counts as a match, and the error contract - because the arms are 1500 lines apart in different
+// workers and any of those drifting is a silently weaker constraint.
+//
+// What counts as EVIDENCE is the one thing each arm supplies itself, because it genuinely differs:
+//
+//   OAuth2 - the addresses the provider returned over a back-channel. Caller-supplied hints
+//            (accountData.email, oauth2.auth.delegatedUser) are excluded on purpose, so for a delegated
+//            or shared mailbox the expectation must name the authenticating principal, not the mailbox.
+//   IMAP   - the address submitted on the form. The credentials still have to authenticate against the
+//            server, but nothing proves the address belongs to that mailbox, so the guarantee is the
+//            weaker "the account is registered under the expected address".
+
+// The error contract published in the POST /v1/authentication/form notes. Integrators match on this
+// string, so it is a public interface - keep it and the description together and in one place.
+const IDENTITY_MISMATCH_ERROR = 'account_identity_mismatch';
+const IDENTITY_MISMATCH_MESSAGE = 'Authenticated account does not match the expected email address';
+
+function normalizeEmail(value) {
+    return typeof value === 'string' ? value.trim().toLowerCase() : '';
+}
+
+// Fails closed: an empty expectation is not a licence to skip the check (callers must not call it in that
+// case), and an empty or unusable identity list means we learned nothing about who authenticated, which
+// is a rejection rather than a pass. That also makes a future provider that forgets to collect its
+// identities reject setups instead of silently admitting them.
+function matchesExpectedIdentity(expectedEmail, identities) {
+    const expected = normalizeEmail(expectedEmail);
+    if (!expected || !Array.isArray(identities)) {
+        return false;
+    }
+
+    return identities.some(identity => normalizeEmail(identity) === expected);
+}
+
+// The expectation that applies to a setup: the one carried by the signed form blob, or failing that the
+// one already pinned to the account it targets.
+//
+// The blob wins because it is a deliberate re-statement by the authenticated caller, and that is what
+// gives a legitimate mailbox migration a way through. A blob carrying none (an older link, or the admin
+// re-authenticate blob) inherits the stored pin instead of clearing it, which is what makes the
+// constraint outlive the single link that introduced it.
+//
+// Redis is read lazily, only on that fallback: a pinned link would otherwise pay a round trip for a value
+// it always discards. Reads the field directly rather than through Account.loadAccountData(), which
+// hgetalls and decrypts the whole record - same single-field pattern as getAccountState().
+// The expectation carried by a pending OAuth2 setup, whichever of the two shapes it arrives in.
+//
+// Both are written by the server for an authenticated caller and stored under a random nonce, so they are
+// equally trustworthy - they differ only because two entry points build the pending record differently.
+// The hosted form (lib/ui-routes/account-routes.js) copies the field into `_meta` alongside redirectUrl;
+// POST /v1/account with oauth2.authorize stores the request payload as-is and rebuilds `_meta` from
+// scratch, leaving the field at the top level. Reading only `_meta` silently skipped the check on that
+// second path - on the very setup that decides which mailbox the account gets bound to - while still
+// persisting the pin afterwards, so the constraint looked active when it had never run.
+function pendingSetupExpectation(accountData, accountMeta) {
+    return (accountMeta && accountMeta.expectedEmail) || (accountData && accountData.expectedEmail) || null;
+}
+
+// Returns the normalized form, so what gets persisted back onto the account does not depend on which
+// branch produced it or on how the caller happened to capitalize the address.
+async function resolveExpectedIdentity(redis, opts) {
+    const { account, blobExpectation } = opts || {};
+
+    const fromBlob = normalizeEmail(blobExpectation);
+    if (fromBlob) {
+        return fromBlob;
+    }
+
+    if (!account) {
+        return null;
+    }
+
+    return normalizeEmail(await redis.hget(`${REDIS_PREFIX}iad:${account}`, 'expectedEmail')) || null;
+}
+
+// The redirect an integrator gets when the setup is rejected. Deliberately carries no `state`: nothing
+// was created, so there is no account state to report.
+function buildIdentityMismatchUrl(redirectUrl, serviceUrl, account) {
+    const url = new URL(redirectUrl, serviceUrl);
+    if (account) {
+        url.searchParams.set('account', account);
+    }
+    url.searchParams.set('error', IDENTITY_MISMATCH_ERROR);
+    url.searchParams.set('error_description', IDENTITY_MISMATCH_MESSAGE);
+    return url.href;
+}
+
+module.exports = {
+    normalizeEmail,
+    matchesExpectedIdentity,
+    pendingSetupExpectation,
+    resolveExpectedIdentity,
+    buildIdentityMismatchUrl,
+    IDENTITY_MISMATCH_MESSAGE
+};

--- a/lib/api-routes/account-routes.js
+++ b/lib/api-routes/account-routes.js
@@ -226,6 +226,8 @@ async function init(args) {
                     name: Joi.string().max(256).required().example('My Email Account').description('Display name for the account'),
                     email: Joi.string().empty('').email().example('user@example.com').description('Default email address of the account'),
 
+                    expectedEmail: accountSchemas.expectedEmail,
+
                     path: accountPathSchema.example(['*']).label('AccountPath'),
 
                     subconnections: accountSchemas.subconnections,
@@ -371,6 +373,8 @@ async function init(args) {
                 payload: Joi.object({
                     name: Joi.string().max(256).example('My Email Account').description('Display name for the account'),
                     email: Joi.string().empty('').email().example('user@example.com').description('Default email address of the account'),
+
+                    expectedEmail: accountSchemas.expectedEmailUpdate,
 
                     path: accountPathSchema.example(['*']).label('AccountPath'),
 
@@ -898,6 +902,7 @@ async function init(args) {
                     'account',
                     'name',
                     'email',
+                    'expectedEmail',
                     'copy',
                     'logs',
                     'notifyFrom',
@@ -1042,6 +1047,8 @@ async function init(args) {
 
                     name: Joi.string().allow('').max(256).example('My Email Account').description('Display name for the account'),
                     email: Joi.string().empty('').email().example('user@example.com').description('Default email address of the account'),
+
+                    expectedEmail: accountSchemas.expectedEmail,
 
                     copy: Joi.boolean().example(true).description('Copy submitted messages to Sent folder'),
                     logs: Joi.boolean().example(false).description('Store recent logs'),
@@ -1368,6 +1375,7 @@ async function init(args) {
                     account: request.payload.account,
                     name: request.payload.name,
                     email: request.payload.email,
+                    expectedEmail: request.payload.expectedEmail,
                     syncFrom: request.payload.syncFrom,
                     notifyFrom: request.payload.notifyFrom,
                     subconnections: request.payload.subconnections,
@@ -1423,7 +1431,10 @@ async function init(args) {
 
         options: {
             description: 'Generate authentication link',
-            notes: 'Generates a redirect link to the hosted authentication form',
+            notes: [
+                'Generates a redirect link to the hosted authentication form',
+                'If `expectedEmail` is set and the user completes the form as a different identity, the setup is rejected before any credentials are stored, and the user is sent to `redirectUrl` with `error=account_identity_mismatch` and an `error_description` instead of the usual `account` and `state` arguments.'
+            ],
             tags: ['api', 'Account'],
 
             plugins: {
@@ -1465,6 +1476,8 @@ async function init(args) {
                         .email()
                         .example('user@example.com')
                         .description('Specifies the default email address for this account. Users can change it if needed.'),
+
+                    expectedEmail: accountSchemas.expectedEmail,
 
                     delegated: Joi.boolean()
                         .empty('')

--- a/lib/oauth/decode-jwt-payload.js
+++ b/lib/oauth/decode-jwt-payload.js
@@ -1,0 +1,39 @@
+'use strict';
+
+// Maximum size of the encoded payload segment we are willing to decode. Real id_tokens are a few
+// hundred bytes of claims; anything larger is malformed or hostile, and the segment reaches us from a
+// provider response we do not otherwise bound.
+const MAX_PAYLOAD_LENGTH = 16 * 1024;
+
+// Decode the claims of a JWT WITHOUT verifying its signature, returning null for anything that does not
+// parse. Never throws - callers treat a null payload as "no claims available" and fall back.
+//
+// Not verifying is deliberate and only safe at the sites that use it: every caller obtained the token
+// from the provider's token endpoint over a direct TLS back-channel POST (lib/oauth/*.js getToken), so
+// authenticity comes from the transport, not from the token. The claims are trustworthy for that reason
+// alone. Do NOT reuse this for a token that arrived through the browser or any other front channel -
+// there the signature is the only thing standing between you and attacker-authored claims.
+function decodeJwtPayload(token) {
+    if (!token || typeof token !== 'string') {
+        return null;
+    }
+
+    const [, encodedPayload] = token.split('.');
+    if (!encodedPayload || encodedPayload.length > MAX_PAYLOAD_LENGTH) {
+        return null;
+    }
+
+    try {
+        const payload = JSON.parse(Buffer.from(encodedPayload, 'base64url').toString());
+        // A JWT payload is a JSON object. Anything else (a bare string, a number, null, an array) is not
+        // a claims set, and returning it would hand callers a value that fails on property access.
+        if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+            return null;
+        }
+        return payload;
+    } catch (err) {
+        return null;
+    }
+}
+
+module.exports = { decodeJwtPayload, MAX_PAYLOAD_LENGTH };

--- a/lib/oauth/outlook-identity.js
+++ b/lib/oauth/outlook-identity.js
@@ -1,0 +1,61 @@
+'use strict';
+
+const { isEmail } = require('../utils/is-email');
+
+// Resolves the Microsoft account identity from the sources the OAuth2 callback can have. Split out of
+// workers/api.js because this is a TRUST BOUNDARY, and a trust boundary that exists only as an ordering
+// of assignments inside a 300-line switch is one nobody can test or review.
+//
+// The sources are not equal:
+//
+//   clientInfo      - Microsoft's `client_info` blob. EmailEngine asks for it (lib/oauth/outlook.js sets
+//                     client_info=1) and it comes back as a query parameter on the FRONT channel, i.e.
+//                     through the user's browser. It is not signed and nothing verifies it, so whoever
+//                     drives the callback URL chooses its contents.
+//   idTokenPayload  - claims from the id_token returned by the token endpoint. Unverified as a token, but
+//                     fetched over a direct TLS POST (see lib/oauth/decode-jwt-payload.js).
+//   profile         - the MS Graph /v1.0/me response, also a back-channel request.
+//
+// Callers pass only the sources their branch actually has: the legacy IMAP-scope branch has clientInfo
+// and the id_token, the Graph branch has the profile.
+//
+// `verifiedIdentities` therefore NEVER contains a clientInfo value. It is the only field callers may use
+// to decide whether an authenticated identity satisfies an expected identity. Both the mailbox address
+// and the user principal name are offered, because either can be the stable identity for a tenant and
+// they routinely differ (user@contoso.com vs user@contoso.onmicrosoft.com).
+//
+// `email` prefers a verified value and falls back to clientInfo only when no back-channel source produced
+// one. That fallback exists for OAuth2 apps predating the User.Read scope; it is rarely reached now, since
+// the id_token carries preferred_username whenever `openid profile` is granted. The precedence matters
+// beyond the identity check: accountData.email is persisted, shown in the admin UI, and used as the
+// default From address, so a spoofable value winning there is a bug in its own right.
+//
+// `username` is the credential EmailEngine authenticates with (XOAUTH2), so it is verified-only with no
+// clientInfo fallback. The profile's userPrincipalName is taken as-is rather than filtered as an address,
+// matching the previous behavior - a tenant whose UPN is not email-shaped must still be able to log in.
+function resolveOutlookUserInfo(sources) {
+    const { clientInfo, idTokenPayload, profile } = sources || {};
+
+    // isEmail already rejects non-strings, so these only normalize a miss to null.
+    const asEmail = value => isEmail(value) || null;
+    const asString = value => (typeof value === 'string' && value ? value : null);
+
+    const profileUpn = asString(profile && profile.userPrincipalName);
+    const idTokenUpn = asEmail(idTokenPayload && idTokenPayload.preferred_username);
+
+    // One list in preference order does both jobs: membership answers "did the provider return this
+    // address", and the first entry is the best address to show. Keeping two orderings in sync by hand
+    // would be a silent bug the moment they drifted.
+    const verifiedIdentities = [
+        ...new Set([asEmail(profile && profile.mail), asEmail(idTokenPayload && idTokenPayload.email), idTokenUpn, asEmail(profileUpn)].filter(Boolean))
+    ];
+
+    return {
+        name: asString(idTokenPayload && idTokenPayload.name) || asString(profile && profile.displayName) || asString(clientInfo && clientInfo.name),
+        email: verifiedIdentities[0] || asEmail(clientInfo && clientInfo.preferred_username),
+        username: idTokenUpn || profileUpn,
+        verifiedIdentities
+    };
+}
+
+module.exports = { resolveOutlookUserInfo };

--- a/lib/schemas.js
+++ b/lib/schemas.js
@@ -1563,6 +1563,13 @@ const messageUpdateSchema = Joi.object({
         }
     });
 
+// The update variant below is derived from this one, so the two cannot drift apart in the published API
+// document - only the "how to clear it" sentence differs.
+const EXPECTED_EMAIL_DESCRIPTION =
+    'Pins the account to an email address. A hosted authentication form setup is rejected unless the identity it authenticates matches this address. For OAuth2 the address is compared against what the provider returns, never against caller-supplied hints, so for a shared or delegated mailbox this must be the authenticating principal rather than the mailbox address. For IMAP it is compared against the address entered on the form, which the credentials do not prove ownership of. Once set, the constraint stays on the account and applies to later reauthentication as well.';
+
+const expectedEmailSchema = Joi.string().empty('').email().example('user@example.com').description(EXPECTED_EMAIL_DESCRIPTION);
+
 const accountSchemas = {
     syncFrom: Joi.date()
         .iso()
@@ -1585,6 +1592,11 @@ const accountSchemas = {
             'Additional mailbox paths to monitor with dedicated IMAP connections for faster change detection. Use sparingly as connection limits are strict.'
         )
         .label('SubconnectionPaths'),
+
+    expectedEmail: expectedEmailSchema,
+
+    // Same field on the update endpoint, where null clears the constraint.
+    expectedEmailUpdate: expectedEmailSchema.allow(null).description(`${EXPECTED_EMAIL_DESCRIPTION} Set to \`null\` to remove the constraint.`),
 
     imapIndexer: Joi.string()
         .empty('')

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -27,6 +27,7 @@ const pathlib = require('path');
 const { randomUUID: uuid } = require('crypto');
 const mimeTypes = require('nodemailer/lib/mime-funcs/mime-types');
 const { v3: murmurhash } = require('murmurhash');
+const { isEmail } = require('./utils/is-email');
 const { compare: compareVersions, validate: validateVersion } = require('compare-versions');
 const {
     REDIS_PREFIX,
@@ -1320,26 +1321,9 @@ MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEV3QUiYsp13nD9suD1/ZkEXnuMoSg
         }
     },
 
-    isEmail(str) {
-        const schema = Joi.object({
-            email: Joi.string().email().required()
-        });
-
-        const { error, value } = schema.validate(
-            { email: str },
-            {
-                abortEarly: false,
-                stripUnknown: true,
-                convert: true
-            }
-        );
-
-        if (error) {
-            return false;
-        }
-
-        return value.email;
-    },
+    // Re-exported from lib/utils/is-email.js so pure modules can use the same check without requiring
+    // this file (and with it settings and Redis). Keep the re-export - callers import it from here.
+    isEmail,
 
     async emitChangeEvent(logger, account, type, key, payload) {
         try {
@@ -1813,6 +1797,7 @@ MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEV3QUiYsp13nD9suD1/ZkEXnuMoSg
                           account: opts.account,
                           name: opts.name,
                           email: opts.email,
+                          expectedEmail: opts.expectedEmail,
                           syncFrom: (opts.syncFrom && opts.syncFrom.toISOString()) || null,
                           notifyFrom: (opts.notifyFrom && opts.notifyFrom.toISOString()) || null,
                           subconnections: opts.subconnections && opts.subconnections.length ? opts.subconnections : null,

--- a/lib/ui-routes/account-routes.js
+++ b/lib/ui-routes/account-routes.js
@@ -34,8 +34,16 @@ const {
     readEnvValue,
     failAction
 } = require('../tools');
-const { settingsSchema, accountIdSchema, defaultAccountTypeSchema, ACCOUNT_DISPLAY_STATES, signedFormBlobFields: signedBlobFields } = require('../schemas');
+const {
+    settingsSchema,
+    accountSchemas,
+    accountIdSchema,
+    defaultAccountTypeSchema,
+    ACCOUNT_DISPLAY_STATES,
+    signedFormBlobFields: signedBlobFields
+} = require('../schemas');
 const { formatAccountData, cachedTemplates, ACCOUNT_STATE_DISPLAY } = require('./route-helpers');
+const { matchesExpectedIdentity, resolveExpectedIdentity, buildIdentityMismatchUrl } = require('../account/expected-identity');
 
 const { REDIS_PREFIX, DEFAULT_PAGE_SIZE, NONCE_BYTES, MAX_FORM_TTL, MAX_FORM_PROBE_ATTEMPTS } = consts;
 
@@ -358,7 +366,7 @@ function init(args) {
 
             accountData.notifyFrom = data.notifyFrom || new Date().toISOString();
 
-            for (let key of ['redirectUrl', 'n', 't']) {
+            for (let key of ['redirectUrl', 'expectedEmail', 'n', 't']) {
                 if (!accountData._meta) {
                     accountData._meta = {};
                 }
@@ -408,6 +416,8 @@ function init(args) {
             return h.redirect(authorizeUrl);
         }
 
+        const expectedEmail = await resolveFormExpectation(data);
+
         return h.view(
             'accounts/register/imap',
             {
@@ -416,7 +426,10 @@ function init(args) {
                     data: request.payload.data,
                     sig: request.payload.sig,
 
-                    email: data.email,
+                    // A pinned link fixes the address, so prefill from the expectation rather than from the
+                    // editable hint and mark it read-only. Cosmetic - the endpoints below enforce it.
+                    email: expectedEmail || data.email,
+                    emailPinned: !!expectedEmail,
                     name: data.name
                 }
             },
@@ -656,6 +669,46 @@ function init(args) {
         return data;
     };
 
+    // The expectation that applies to a parsed form blob (lib/account/expected-identity.js owns the
+    // precedence and the lazy Redis fallback).
+    const resolveFormExpectation = data => resolveExpectedIdentity(redis, { account: data.account, blobExpectation: data.expectedEmail });
+
+    // Expected identity gate for the IMAP arm, mirroring the one the OAuth callback applies in
+    // workers/api.js.
+    //
+    // The evidence here is only the address typed into the form. Working credentials do not prove that
+    // the address belongs to the mailbox behind them, so this enforces "the account is registered under
+    // the expected address" and nothing stronger - which is exactly what the field documents. Without it
+    // the constraint would be trivially sidestepped by choosing the IMAP tab on a form that also offers
+    // OAuth2.
+    //
+    // Returns { expectedEmail, matched } rather than throwing, because the two call sites reject
+    // differently: the account-creating endpoint owes the integrator the documented redirect, while the
+    // mid-flow page-1 step must not eject the user from the form over a correctable typo.
+    const checkExpectedIdentity = async (data, submittedEmail) => {
+        const expectedEmail = await resolveFormExpectation(data);
+        return { expectedEmail, matched: !expectedEmail || matchesExpectedIdentity(expectedEmail, [submittedEmail]) };
+    };
+
+    const identityMismatchError = gt => {
+        let error = Boom.boomify(new Error(gt.gettext('This setup link cannot be used with this email address')), { statusCode: 403 });
+        error.output.payload.code = 'AccountIdentityMismatch';
+        return error;
+    };
+
+    // have to use HTML redirect, otherwise samesite=strict cookies are not passed on
+    const renderRedirect = (request, h, httpRedirectUrl) =>
+        h.view(
+            'redirect',
+            {
+                pageTitleFull: request.app.gt.gettext('Email Account Setup'),
+                httpRedirectUrl
+            },
+            {
+                layout: 'public'
+            }
+        );
+
     server.route({
         method: 'POST',
         path: '/accounts/new/imap',
@@ -663,7 +716,16 @@ function init(args) {
         async handler(request, h) {
             // Bound outbound autodiscovery per issued blob (shared cap with the connection tester) so a
             // leaked signed link cannot drive unlimited outbound probes to arbitrary domains.
-            await authorizeSignedProbe(request.payload, request.app.gt, request.logger);
+            const data = await authorizeSignedProbe(request.payload, request.app.gt, request.logger);
+
+            // Reject a pinned link early, before autodiscovery runs against the submitted domain. The
+            // authoritative check is on the create endpoint below; this one exists so the user finds out
+            // before typing a password. No redirect here - this is a mid-flow step, and the form prefills
+            // the pinned address, so reaching it with a mismatch means a hand-crafted request.
+            const identity = await checkExpectedIdentity(data, request.payload.email);
+            if (!identity.matched) {
+                throw identityMismatchError(request.app.gt);
+            }
 
             let serverSettings;
             try {
@@ -909,6 +971,18 @@ function init(args) {
         async handler(request, h) {
             const data = await parseSignedFormData(redis, request.payload, request.app.gt, { requireNonce: true });
 
+            // Before the nonce claim below, so a rejected attempt does not consume the setup link. This is
+            // the terminal step, so a mismatch owes the integrator the documented redirect
+            // (error=account_identity_mismatch) rather than an EmailEngine error page - the same contract
+            // the OAuth callback honors.
+            const { expectedEmail, matched } = await checkExpectedIdentity(data, request.payload.email);
+            if (!matched) {
+                if (!data.redirectUrl) {
+                    throw identityMismatchError(request.app.gt);
+                }
+                return renderRedirect(request, h, buildIdentityMismatchUrl(data.redirectUrl, await settings.get('serviceUrl'), data.account));
+            }
+
             const accountData = {
                 account: data.account || null,
                 name: request.payload.name || data.name,
@@ -944,6 +1018,11 @@ function init(args) {
 
             if (data.subconnections && data.subconnections.length) {
                 accountData.subconnections = data.subconnections;
+            }
+
+            if (expectedEmail) {
+                // Pin the account so later setups are checked even from a link that carries no expectation.
+                accountData.expectedEmail = expectedEmail;
             }
 
             const accountObject = new Account({ redis, call, secret: await getSecret() });
@@ -1000,16 +1079,7 @@ function init(args) {
                 httpRedirectUrl = `/admin/accounts/${result.account}`;
             }
 
-            return h.view(
-                'redirect',
-                {
-                    pageTitleFull: request.app.gt.gettext('Email Account Setup'),
-                    httpRedirectUrl
-                },
-                {
-                    layout: 'public'
-                }
-            );
+            return renderRedirect(request, h, httpRedirectUrl);
         },
         options: {
             auth: false,
@@ -1766,6 +1836,9 @@ function init(args) {
                     account: request.params.account,
                     name: request.payload.name || '',
                     email: request.payload.email,
+                    // Empty clears the pin (Account.update hdel's it), which is the only way an operator
+                    // can unblock a legitimate mailbox migration on a pinned account.
+                    expectedEmail: request.payload.expectedEmail || null,
                     proxy: request.payload.proxy,
                     smtpEhloName: request.payload.smtpEhloName,
                     webhooks: request.payload.webhooks
@@ -1966,6 +2039,8 @@ function init(args) {
                 payload: Joi.object({
                     name: Joi.string().empty('').max(256).example('John Smith').description('Account Name'),
                     email: Joi.string().email().required().example('user@example.com').label('Email').description('Your account email'),
+
+                    expectedEmail: accountSchemas.expectedEmail,
 
                     proxy: settingsSchema.proxyUrl,
                     smtpEhloName: settingsSchema.smtpEhloName,

--- a/lib/utils/is-email.js
+++ b/lib/utils/is-email.js
@@ -1,0 +1,34 @@
+'use strict';
+
+const Joi = require('joi');
+
+// Built once. joi schemas are immutable and meant to be reused, and compiling this per call measured
+// ~5x slower - which matters because unserializeAccountData() calls isEmail() for every OAuth2 account
+// that has no stored email, and the account listing maps that over every row of a page.
+const emailSchema = Joi.object({
+    email: Joi.string().email().required()
+});
+
+const validateOptions = {
+    abortEarly: false,
+    stripUnknown: true,
+    convert: true
+};
+
+// Syntactic check only - it says the string is shaped like an address, never that the address is real
+// or that whoever supplied it controls it. Trust decisions belong to the caller.
+//
+// Lives here rather than in lib/tools.js so the pure modules that need it (lib/oauth/outlook-identity.js)
+// do not have to require tools, which pulls in settings and a Redis connection. lib/tools.js re-exports
+// this function, so every existing caller is unaffected.
+function isEmail(str) {
+    const { error, value } = emailSchema.validate({ email: str }, validateOptions);
+
+    if (error) {
+        return false;
+    }
+
+    return value.email;
+}
+
+module.exports = { isEmail };

--- a/test/account-reauth-reconnect-test.js
+++ b/test/account-reauth-reconnect-test.js
@@ -413,3 +413,83 @@ test('Account.update serialization', async t => {
         assert.deepStrictEqual(result, { account: 'acc16' });
     });
 });
+
+// Persisting a partial update. An empty payload - and, before serializeAccountData learned to write a
+// cleared marker, a payload that only removed a field - serializes to no field/value pairs at all. Redis
+// rejects an hmset with none ("wrong number of arguments"), which surfaced as a 500 on a valid request,
+// so the write has to be skipped rather than issued empty.
+test('Account.update field persistence', async t => {
+    // Records the commands queued on the pipeline. The shared mock above accepts anything and always
+    // reports OK, which is precisely why the empty-hmset bug went unnoticed there.
+    function createRecordingCtx(serialized) {
+        const commands = [];
+        const pipeline = {
+            exec: async () => commands.map(command => [null, command.name === 'hmset' ? 'OK' : 1]),
+            hmset(key, fields) {
+                commands.push({ name: 'hmset', key, fields });
+                return this;
+            },
+            hdel(key, field) {
+                commands.push({ name: 'hdel', key, field });
+                return this;
+            },
+            hset() {
+                return this;
+            },
+            sadd() {
+                return this;
+            },
+            srem() {
+                return this;
+            }
+        };
+
+        // Same collaborators as createCtx above; only the pipeline and the serializer differ.
+        const { ctx } = createCtx({ account: 'acc-fields', state: 'connected' });
+        Object.assign(ctx, {
+            redis: Object.assign({}, mockRedis, { multi: () => pipeline }),
+            getAccountKey: () => 'iad:acc-fields',
+            serializeAccountData: () => serialized
+        });
+
+        return { ctx, commands };
+    }
+
+    await t.test('writes the serialized fields when there are any', async () => {
+        const { ctx, commands } = createRecordingCtx({ name: 'Nyan Cat' });
+
+        await Account.prototype.update.call(ctx, { account: 'acc-fields', name: 'Nyan Cat' });
+
+        assert.deepStrictEqual(
+            commands.map(command => command.name),
+            ['hmset']
+        );
+        assert.deepStrictEqual(commands[0].fields, { name: 'Nyan Cat' });
+    });
+
+    await t.test('skips the write when the payload serializes to nothing', async () => {
+        const { ctx, commands } = createRecordingCtx({});
+
+        await assert.doesNotReject(Account.prototype.update.call(ctx, { account: 'acc-fields' }));
+
+        assert.deepStrictEqual(commands, [], 'an empty hmset must never be queued');
+    });
+});
+
+// The identity pin has to be removable, so it cannot ride serializeAccountData's default branch: that
+// drops nulls, and hmset only ever adds keys, which would leave the pin settable but never clearable.
+test('Account expectedEmail round-trip', async t => {
+    const serialize = accountData => Account.prototype.serializeAccountData.call({ logger: createMockLogger() }, accountData);
+    const unserialize = accountData => Account.prototype.unserializeAccountData.call({ logger: createMockLogger() }, accountData);
+
+    await t.test('stores an address and reads it back', () => {
+        assert.strictEqual(serialize({ expectedEmail: 'owner@example.com' }).expectedEmail, 'owner@example.com');
+        assert.strictEqual(unserialize({ expectedEmail: 'owner@example.com' }).expectedEmail, 'owner@example.com');
+    });
+
+    await t.test('clearing writes a marker that reads back as unset', () => {
+        // null must survive into the write, otherwise the stored value would simply persist.
+        assert.strictEqual(serialize({ expectedEmail: null }).expectedEmail, '');
+        assert.ok(!('expectedEmail' in unserialize({ expectedEmail: '' })), 'a cleared pin must not be reported as set');
+    });
+});

--- a/test/api-reference-test.js
+++ b/test/api-reference-test.js
@@ -152,7 +152,7 @@ test('API reference model', async t => {
         // declared order is preserved within each group, so grouping never reshuffles the
         // optional tail
         const optional = account.body.tree.children.filter(child => !child.required).map(child => child.name);
-        assert.deepEqual(optional.slice(0, 3), ['email', 'path', 'subconnections']);
+        assert.deepEqual(optional.slice(0, 3), ['email', 'expectedEmail', 'path']);
 
         for (const operation of allOperations) {
             for (const group of [operation.queryParams, operation.headerParams]) {

--- a/test/decode-jwt-payload-test.js
+++ b/test/decode-jwt-payload-test.js
@@ -1,0 +1,47 @@
+'use strict';
+
+// Tests for lib/oauth/decode-jwt-payload.js. The contract that matters is that it NEVER throws: the OAuth2
+// callback decodes id_tokens from three providers on an unauthenticated route, and a malformed token has
+// to degrade to "no claims available", not to a 500.
+
+const test = require('node:test');
+const assert = require('node:assert').strict;
+
+const { decodeJwtPayload, MAX_PAYLOAD_LENGTH } = require('../lib/oauth/decode-jwt-payload');
+
+const encode = value => Buffer.from(JSON.stringify(value)).toString('base64url');
+const jwt = payload => `header.${encode(payload)}.signature`;
+
+test('decodeJwtPayload()', async t => {
+    await t.test('returns the claims of a well-formed token', () => {
+        const payload = { email: 'user@example.com', name: 'Nyan Cat', preferred_username: 'nyan@example.com' };
+        assert.deepEqual(decodeJwtPayload(jwt(payload)), payload);
+    });
+
+    await t.test('returns null for tokens it cannot decode', () => {
+        assert.equal(decodeJwtPayload(''), null);
+        assert.equal(decodeJwtPayload('not-a-jwt'), null);
+        assert.equal(decodeJwtPayload('header..signature'), null);
+        assert.equal(decodeJwtPayload('header.!!!not-base64!!!.signature'), null);
+        assert.equal(decodeJwtPayload(`header.${Buffer.from('not json').toString('base64url')}.signature`), null);
+    });
+
+    await t.test('returns null for a payload that is not a claims object', () => {
+        // A bare string or array decodes as valid JSON but is not a claims set, and returning it would
+        // hand callers a value that breaks on property access.
+        for (const value of ['a string', 42, null, true, ['a', 'b']]) {
+            assert.equal(decodeJwtPayload(jwt(value)), null);
+        }
+    });
+
+    await t.test('returns null for non-string input', () => {
+        for (const value of [undefined, null, 42, {}, [], Buffer.from('x')]) {
+            assert.equal(decodeJwtPayload(value), null);
+        }
+    });
+
+    await t.test('refuses to decode an oversized payload segment', () => {
+        const huge = 'a'.repeat(MAX_PAYLOAD_LENGTH + 1);
+        assert.equal(decodeJwtPayload(`header.${huge}.signature`), null);
+    });
+});

--- a/test/expected-identity-test.js
+++ b/test/expected-identity-test.js
@@ -1,0 +1,157 @@
+'use strict';
+
+// Tests for lib/account/expected-identity.js - the comparison and precedence rules shared by the OAuth2
+// callback (workers/api.js) and the IMAP arm of the hosted form (lib/ui-routes/account-routes.js).
+
+const test = require('node:test');
+const assert = require('node:assert').strict;
+
+const {
+    normalizeEmail,
+    matchesExpectedIdentity,
+    pendingSetupExpectation,
+    resolveExpectedIdentity,
+    buildIdentityMismatchUrl
+} = require('../lib/account/expected-identity');
+
+test('matchesExpectedIdentity()', async t => {
+    await t.test('matches case-insensitively and ignores surrounding whitespace', () => {
+        assert.equal(matchesExpectedIdentity(' Owner@Example.com ', ['owner@example.com']), true);
+        assert.equal(matchesExpectedIdentity('owner@example.com', ['  OWNER@EXAMPLE.COM']), true);
+    });
+
+    await t.test('accepts any one of several provider identities', () => {
+        // Microsoft returns both a mailbox address and a user principal name, and either can be the
+        // stable identity for a tenant.
+        const identities = ['nyan@contoso.com', 'nyan@contoso.onmicrosoft.com'];
+        assert.equal(matchesExpectedIdentity('nyan@contoso.onmicrosoft.com', identities), true);
+        assert.equal(matchesExpectedIdentity('nyan@contoso.com', identities), true);
+    });
+
+    await t.test('rejects an address the provider did not return', () => {
+        assert.equal(matchesExpectedIdentity('owner@example.com', ['attacker@example.com']), false);
+    });
+
+    await t.test('fails closed when there is no identity evidence at all', () => {
+        // A provider case that collects nothing must reject rather than admit. This is what keeps a future
+        // provider that forgets to report its identities from silently disabling the constraint.
+        assert.equal(matchesExpectedIdentity('owner@example.com', []), false);
+        assert.equal(matchesExpectedIdentity('owner@example.com', [null, undefined, '', false, 0]), false);
+    });
+
+    await t.test('fails closed on an empty expectation or a non-array identity list', () => {
+        assert.equal(matchesExpectedIdentity('', ['owner@example.com']), false);
+        assert.equal(matchesExpectedIdentity(null, ['owner@example.com']), false);
+        assert.equal(matchesExpectedIdentity('   ', ['owner@example.com']), false);
+        assert.equal(matchesExpectedIdentity('owner@example.com', null), false);
+        assert.equal(matchesExpectedIdentity('owner@example.com', 'owner@example.com'), false);
+    });
+
+    await t.test('does not treat a substring or a lookalike as a match', () => {
+        assert.equal(matchesExpectedIdentity('owner@example.com', ['owner@example.com.evil.test']), false);
+        assert.equal(matchesExpectedIdentity('owner@example.com', ['owner@example.co']), false);
+        assert.equal(matchesExpectedIdentity('owner@example.com', ['xowner@example.com']), false);
+    });
+});
+
+test('resolveExpectedIdentity()', async t => {
+    // Records reads so the tests can assert that Redis is touched only when it has to be.
+    const stubRedis = stored => {
+        const reads = [];
+        return {
+            reads,
+            hget: async (key, field) => {
+                reads.push({ key, field });
+                return stored;
+            }
+        };
+    };
+
+    await t.test('prefers the expectation carried by the signed form blob', async () => {
+        // A freshly signed blob is a deliberate re-statement by the authenticated caller, which is how a
+        // legitimate mailbox migration gets through a pinned account.
+        const redis = stubRedis('old@example.com');
+        assert.equal(await resolveExpectedIdentity(redis, { account: 'acc', blobExpectation: 'new@example.com' }), 'new@example.com');
+        // And the stored value is never even read, since it could not have changed the answer.
+        assert.deepEqual(redis.reads, []);
+    });
+
+    await t.test('falls back to the expectation stored on the account', async () => {
+        // A link with no expectation of its own (an older link, or the admin re-authenticate blob) must
+        // inherit the pin rather than clear it - otherwise the constraint would not outlive one link.
+        for (const blobExpectation of [undefined, '', '  ']) {
+            const redis = stubRedis('owner@example.com');
+            assert.equal(await resolveExpectedIdentity(redis, { account: 'acc', blobExpectation }), 'owner@example.com');
+            assert.deepEqual(redis.reads, [{ key: 'iad:acc', field: 'expectedEmail' }]);
+        }
+    });
+
+    await t.test('treats the cleared marker on the account as no expectation', async () => {
+        // serializeAccountData writes '' to clear a pin rather than deleting the field.
+        const redis = stubRedis('');
+        assert.equal(await resolveExpectedIdentity(redis, { account: 'acc' }), null);
+    });
+
+    await t.test('returns null when neither side pins an identity', async () => {
+        assert.equal(await resolveExpectedIdentity(stubRedis(null), { account: 'acc' }), null);
+        // No account to look up: no read at all.
+        const redis = stubRedis('owner@example.com');
+        assert.equal(await resolveExpectedIdentity(redis, {}), null);
+        assert.equal(await resolveExpectedIdentity(redis), null);
+        assert.deepEqual(redis.reads, []);
+    });
+});
+
+test('pendingSetupExpectation()', async t => {
+    // Two entry points build the pending OAuth2 record differently, and reading only one of them skipped
+    // the check entirely on the other - on the setup that decides which mailbox gets bound, while still
+    // persisting the pin afterwards so it looked active. Both shapes must be honored.
+    await t.test('reads the hosted form shape, where the pin sits in _meta', () => {
+        assert.equal(pendingSetupExpectation({ account: 'acc' }, { expectedEmail: 'owner@example.com' }), 'owner@example.com');
+    });
+
+    await t.test('reads the POST /v1/account shape, where the pin stays at the top level', () => {
+        assert.equal(
+            pendingSetupExpectation({ account: 'acc', expectedEmail: 'owner@example.com' }, { redirectUrl: 'https://app.example.com' }),
+            'owner@example.com'
+        );
+    });
+
+    await t.test('prefers _meta when a record somehow carries both', () => {
+        assert.equal(pendingSetupExpectation({ expectedEmail: 'top@example.com' }, { expectedEmail: 'meta@example.com' }), 'meta@example.com');
+    });
+
+    await t.test('returns null when neither shape carries one', () => {
+        assert.equal(pendingSetupExpectation({ account: 'acc' }, {}), null);
+        assert.equal(pendingSetupExpectation(null, null), null);
+        assert.equal(pendingSetupExpectation(), null);
+    });
+});
+
+test('buildIdentityMismatchUrl()', async t => {
+    await t.test('carries the documented error contract and no state', () => {
+        const href = buildIdentityMismatchUrl('https://app.example.com/done', 'https://ee.example.com', 'acc1');
+        const url = new URL(href);
+
+        assert.equal(url.searchParams.get('error'), 'account_identity_mismatch');
+        assert.ok(url.searchParams.get('error_description'), 'integrators are told why');
+        assert.equal(url.searchParams.get('account'), 'acc1');
+        // Nothing was created, so there is no account state to report.
+        assert.equal(url.searchParams.get('state'), null);
+    });
+
+    await t.test('resolves a relative redirect against the service URL and omits an unknown account', () => {
+        const href = buildIdentityMismatchUrl('/done', 'https://ee.example.com', null);
+        assert.equal(new URL(href).origin, 'https://ee.example.com');
+        assert.equal(new URL(href).searchParams.get('account'), null);
+    });
+});
+
+test('normalizeEmail()', async t => {
+    await t.test('lowercases and trims strings, and maps everything else to an empty string', () => {
+        assert.equal(normalizeEmail('  User@Example.COM '), 'user@example.com');
+        for (const value of [null, undefined, 42, {}, [], true]) {
+            assert.equal(normalizeEmail(value), '');
+        }
+    });
+});

--- a/test/fixtures/openapi-golden.json
+++ b/test/fixtures/openapi-golden.json
@@ -597,6 +597,14 @@
               "email": true
             }
           },
+          "expectedEmail": {
+            "type": "string",
+            "description": "Pins the account to an email address. A hosted authentication form setup is rejected unless the identity it authenticates matches this address. For OAuth2 the address is compared against what the provider returns, never against caller-supplied hints, so for a shared or delegated mailbox this must be the authenticating principal rather than the mailbox address. For IMAP it is compared against the address entered on the form, which the credentials do not prove ownership of. Once set, the constraint stays on the account and applies to later reauthentication as well.",
+            "example": "user@example.com",
+            "x-format": {
+              "email": true
+            }
+          },
           "path": {
             "$ref": "#/components/schemas/AccountPath"
           },
@@ -1559,6 +1567,14 @@
               "email": true
             }
           },
+          "expectedEmail": {
+            "type": "string",
+            "description": "Pins the account to an email address. A hosted authentication form setup is rejected unless the identity it authenticates matches this address. For OAuth2 the address is compared against what the provider returns, never against caller-supplied hints, so for a shared or delegated mailbox this must be the authenticating principal rather than the mailbox address. For IMAP it is compared against the address entered on the form, which the credentials do not prove ownership of. Once set, the constraint stays on the account and applies to later reauthentication as well.",
+            "example": "user@example.com",
+            "x-format": {
+              "email": true
+            }
+          },
           "copy": {
             "type": "boolean",
             "description": "Copy submitted messages to Sent folder",
@@ -2033,6 +2049,15 @@
             "type": "string",
             "description": "Default email address of the account",
             "example": "user@example.com",
+            "x-format": {
+              "email": true
+            }
+          },
+          "expectedEmail": {
+            "type": "string",
+            "description": "Pins the account to an email address. A hosted authentication form setup is rejected unless the identity it authenticates matches this address. For OAuth2 the address is compared against what the provider returns, never against caller-supplied hints, so for a shared or delegated mailbox this must be the authenticating principal rather than the mailbox address. For IMAP it is compared against the address entered on the form, which the credentials do not prove ownership of. Once set, the constraint stays on the account and applies to later reauthentication as well. Set to `null` to remove the constraint.",
+            "example": "user@example.com",
+            "nullable": true,
             "x-format": {
               "email": true
             }
@@ -6143,6 +6168,14 @@
           "email": {
             "type": "string",
             "description": "Specifies the default email address for this account. Users can change it if needed.",
+            "example": "user@example.com",
+            "x-format": {
+              "email": true
+            }
+          },
+          "expectedEmail": {
+            "type": "string",
+            "description": "Pins the account to an email address. A hosted authentication form setup is rejected unless the identity it authenticates matches this address. For OAuth2 the address is compared against what the provider returns, never against caller-supplied hints, so for a shared or delegated mailbox this must be the authenticating principal rather than the mailbox address. For IMAP it is compared against the address entered on the form, which the credentials do not prove ownership of. Once set, the constraint stays on the account and applies to later reauthentication as well.",
             "example": "user@example.com",
             "x-format": {
               "email": true
@@ -16584,7 +16617,7 @@
       "post": {
         "summary": "Generate authentication link",
         "operationId": "postV1AuthenticationForm",
-        "description": "Generates a redirect link to the hosted authentication form",
+        "description": "Generates a redirect link to the hosted authentication form<br/><br/>If `expectedEmail` is set and the user completes the form as a different identity, the setup is rejected before any credentials are stored, and the user is sent to `redirectUrl` with `error=account_identity_mismatch` and an `error_description` instead of the usual `account` and `state` arguments.",
         "parameters": [
           {
             "name": "x-ee-timeout",

--- a/test/integration/hosted-form-test.js
+++ b/test/integration/hosted-form-test.js
@@ -52,6 +52,13 @@ const serverFields = Object.assign({ email: 'user@example.com', imap_disabled: '
 // Static access token (scope "*") from config/test.toml - verifies created accounts and cleans up.
 const authed = supertest.agent(baseUrl).auth(ACCESS_TOKEN, { type: 'bearer' });
 
+// The setup endpoints answer with an HTML redirect page rather than a Location header, so the created
+// account id has to come out of the rendered link.
+function extractAccountId(text) {
+    const m = /account=([^&"'<>\s]+)/.exec(text || '');
+    return m ? m[1] : null;
+}
+
 async function crumbAgent() {
     const agent = supertest.agent(baseUrl);
     const page = await agent.get('/admin/login');
@@ -190,11 +197,6 @@ test('Hosted form account creation dedupes the single-use nonce', async t => {
         }
     });
 
-    const extractAccountId = text => {
-        const m = /account=([^&"'<>\s]+)/.exec(text || '');
-        return m ? m[1] : null;
-    };
-
     const submitFields = crumb => {
         const n = crypto.randomBytes(16).toString('base64url');
         const { data, sig } = signBlob({ n, t: Date.now(), redirectUrl: 'https://example.com/done' });
@@ -235,6 +237,112 @@ test('Hosted form account creation dedupes the single-use nonce', async t => {
         // Same signed blob (same nonce): now consumed, so the replay must be rejected.
         const replay = await agent.post('/accounts/new/imap/server').type('form').send(fields);
         assert.equal(replay.status, 403, `replay should be rejected, got ${replay.status}`);
+    });
+});
+
+test('Hosted form enforces the expected account identity on the IMAP arm', async t => {
+    // The IMAP arm is the sidestep the OAuth-only version of this constraint left open: a form that offers
+    // both tabs would let the user pick IMAP and attach any mailbox with a password. The evidence here is
+    // only the submitted address (working credentials do not prove the address belongs to that mailbox),
+    // so what is asserted is "the account is registered under the expected address, or not at all".
+    const createdAccounts = [];
+
+    t.after(async () => {
+        for (const id of createdAccounts) {
+            await authed.delete(`/v1/account/${id}`).catch(() => {});
+        }
+    });
+
+    const submit = async (blob, overrides) => {
+        const { agent, crumb } = await crumbAgent();
+        const { data, sig } = signBlob(Object.assign({ n: crypto.randomBytes(16).toString('base64url'), t: Date.now() }, blob));
+        return agent
+            .post('/accounts/new/imap/server')
+            .type('form')
+            .send(Object.assign({ crumb, data, sig }, serverFields, overrides));
+    };
+
+    await t.test('a matching address is accepted and the pin is stored on the account', async () => {
+        const res = await submit({ expectedEmail: 'user@example.com', redirectUrl: 'https://example.com/done' });
+        assert.equal(res.status, 200, `expected 200, got ${res.status}: ${res.text}`);
+
+        const id = extractAccountId(res.text);
+        assert.ok(id, 'the successful response should reference the created account id');
+        createdAccounts.push(id);
+
+        // Persisted, so it also applies to later setups driven by a link that carries no expectation.
+        const acct = await authed.get(`/v1/account/${id}`);
+        assert.equal(acct.status, 200, 'the created account should exist');
+        assert.equal(acct.body.expectedEmail, 'user@example.com', 'the expectation should be pinned to the account');
+    });
+
+    await t.test('a different address is rejected and no account is created', async () => {
+        const account = `identity-mismatch-${crypto.randomBytes(6).toString('hex')}`;
+        const res = await submit({ account, expectedEmail: 'owner@example.com' }, { email: 'someone-else@example.com' });
+
+        assert.equal(res.status, 403, `expected 403, got ${res.status}: ${res.text}`);
+        // The rejection must happen before create(), not after - an account written and then reported as
+        // rejected would be the exact failure this constraint exists to prevent.
+        const acct = await authed.get(`/v1/account/${account}`);
+        assert.equal(acct.status, 404, 'the rejected setup must not have created an account');
+    });
+
+    await t.test('a rejection with a redirectUrl honors the documented error contract', async () => {
+        // POST /v1/authentication/form documents error=account_identity_mismatch on the redirect. That
+        // promise is made for the whole form, so the IMAP arm has to keep it too, not just the OAuth arm.
+        const account = `identity-redirect-${crypto.randomBytes(6).toString('hex')}`;
+        const res = await submit(
+            { account, expectedEmail: 'owner@example.com', redirectUrl: 'https://example.com/done' },
+            { email: 'someone-else@example.com' }
+        );
+
+        assert.equal(res.status, 200, `expected a redirect page, got ${res.status}: ${res.text}`);
+        assert.match(res.text, /error=account_identity_mismatch/, 'the redirect must carry the documented error code');
+        assert.match(res.text, /error_description=/, 'the redirect must explain why');
+        assert.ok(!/[?&]state=/.test(res.text), 'nothing was created, so no account state may be reported');
+
+        const acct = await authed.get(`/v1/account/${account}`);
+        assert.equal(acct.status, 404, 'the rejected setup must not have created an account');
+    });
+
+    await t.test('a stored pin applies to a link that carries no expectation of its own', async () => {
+        const account = `identity-stored-${crypto.randomBytes(6).toString('hex')}`;
+        const created = await authed.post('/v1/account').send({
+            account,
+            name: 'Pinned Account',
+            email: 'owner@example.com',
+            expectedEmail: 'owner@example.com',
+            imap: { auth: { user: 'owner@example.com', pass: 'secret' }, host: '127.0.0.1', port: 1, secure: false },
+            smtp: { auth: { user: 'owner@example.com', pass: 'secret' }, host: '127.0.0.1', port: 1, secure: false }
+        });
+        assert.equal(created.status, 200, `account setup failed: ${created.text}`);
+        createdAccounts.push(account);
+
+        // No expectedEmail in the blob: this is the admin re-authenticate case, and an older API-issued
+        // link behaves the same. The pin must be inherited rather than dropped.
+        const rejected = await submit({ account }, { email: 'someone-else@example.com' });
+        assert.equal(rejected.status, 403, `expected the stored pin to reject, got ${rejected.status}`);
+
+        // And clearing it through the authenticated API lets the same submission through, which is the
+        // escape hatch for a legitimate mailbox migration.
+        const cleared = await authed.put(`/v1/account/${account}`).send({ expectedEmail: null });
+        assert.equal(cleared.status, 200, `failed to clear the pin: ${cleared.text}`);
+
+        const accepted = await submit({ account }, { email: 'someone-else@example.com' });
+        assert.equal(accepted.status, 200, `expected the cleared account to accept, got ${accepted.status}: ${accepted.text}`);
+    });
+
+    await t.test('page 1 rejects a mismatched address before autodiscovery runs', async () => {
+        const { agent, crumb } = await crumbAgent();
+        const { data, sig } = signBlob({
+            expectedEmail: 'owner@example.com',
+            n: crypto.randomBytes(16).toString('base64url'),
+            t: Date.now()
+        });
+
+        const res = await agent.post('/accounts/new/imap').type('form').send({ crumb, data, sig, email: 'someone-else@example.com', password: 'secret' });
+
+        assert.equal(res.status, 403, `expected 403, got ${res.status}`);
     });
 });
 

--- a/test/outlook-identity-test.js
+++ b/test/outlook-identity-test.js
@@ -1,0 +1,107 @@
+'use strict';
+
+// Trust-boundary tests for lib/oauth/outlook-identity.js.
+//
+// The property under test is not "the right name comes out", it is WHICH SOURCE is allowed to decide the
+// identity. Microsoft's `client_info` reaches the OAuth2 callback as an unsigned query parameter on the
+// front channel, so whoever drives the callback URL writes it; the id_token and the Graph profile arrive
+// over the back channel. Because the default MS365 base scopes (`openid profile`, no `email`) mean the
+// id_token usually has no `email` claim, a client_info value used to be able to survive as the account's
+// email address - and would have satisfied an expectedEmail constraint. These tests pin that shut.
+
+const test = require('node:test');
+const assert = require('node:assert').strict;
+
+const { resolveOutlookUserInfo } = require('../lib/oauth/outlook-identity');
+
+test('resolveOutlookUserInfo()', async t => {
+    await t.test('never treats a client_info value as identity evidence', () => {
+        // The exact shape of the attack: consent as attacker@example.com, then hand-edit the callback URL
+        // so client_info claims the owner. The id_token carries no `email` claim, which is the norm.
+        const userInfo = resolveOutlookUserInfo({
+            clientInfo: { name: 'Owner', preferred_username: 'owner@example.com' },
+            idTokenPayload: { name: 'Attacker', preferred_username: 'attacker@example.com' }
+        });
+
+        assert.deepEqual(userInfo.verifiedIdentities, ['attacker@example.com']);
+        assert.ok(!userInfo.verifiedIdentities.includes('owner@example.com'), 'a client_info address must never be verified evidence');
+        // It must not win the persisted address either - that feeds the default From address.
+        assert.equal(userInfo.email, 'attacker@example.com');
+        assert.equal(userInfo.username, 'attacker@example.com');
+    });
+
+    await t.test('a back-channel address wins over client_info for the account email', () => {
+        const userInfo = resolveOutlookUserInfo({
+            clientInfo: { preferred_username: 'spoofed@example.com' },
+            idTokenPayload: { email: 'real@example.com', preferred_username: 'real@example.onmicrosoft.com' }
+        });
+
+        assert.equal(userInfo.email, 'real@example.com');
+        assert.deepEqual(userInfo.verifiedIdentities, ['real@example.com', 'real@example.onmicrosoft.com']);
+    });
+
+    await t.test('falls back to client_info only when no back-channel source produced an address', () => {
+        // Legacy apps predating the User.Read scope: nothing but client_info is available. The fallback is
+        // kept so those setups still work, but the value stays out of verifiedIdentities, so a pinned
+        // account cannot be taken over through it - it just fails the check.
+        const userInfo = resolveOutlookUserInfo({
+            clientInfo: { name: 'Legacy User', preferred_username: 'legacy@example.com' }
+        });
+
+        assert.equal(userInfo.email, 'legacy@example.com');
+        assert.equal(userInfo.name, 'Legacy User');
+        assert.deepEqual(userInfo.verifiedIdentities, []);
+        assert.equal(userInfo.username, null);
+    });
+
+    await t.test('offers both the mailbox address and the user principal name from the Graph profile', () => {
+        // Either can be the stable identity for a tenant, and they routinely differ.
+        const userInfo = resolveOutlookUserInfo({
+            profile: { displayName: 'Nyan Cat', mail: 'nyan@contoso.com', userPrincipalName: 'nyan@contoso.onmicrosoft.com' }
+        });
+
+        assert.equal(userInfo.name, 'Nyan Cat');
+        assert.equal(userInfo.email, 'nyan@contoso.com');
+        assert.equal(userInfo.username, 'nyan@contoso.onmicrosoft.com');
+        assert.deepEqual(userInfo.verifiedIdentities, ['nyan@contoso.com', 'nyan@contoso.onmicrosoft.com']);
+    });
+
+    await t.test('keeps a user principal name that is not email-shaped as the login credential', () => {
+        // username is what XOAUTH2 authenticates with, so it is passed through as-is. It is not offered as
+        // identity evidence, because the comparison is against an email address.
+        const userInfo = resolveOutlookUserInfo({
+            profile: { mail: 'nyan@contoso.com', userPrincipalName: 'CONTOSO\\nyan' }
+        });
+
+        assert.equal(userInfo.username, 'CONTOSO\\nyan');
+        assert.deepEqual(userInfo.verifiedIdentities, ['nyan@contoso.com']);
+    });
+
+    await t.test('deduplicates identities so the same address is not reported twice', () => {
+        const userInfo = resolveOutlookUserInfo({
+            idTokenPayload: { email: 'same@example.com', preferred_username: 'same@example.com' }
+        });
+
+        assert.deepEqual(userInfo.verifiedIdentities, ['same@example.com']);
+    });
+
+    await t.test('drops values that are not email addresses instead of passing them through', () => {
+        const userInfo = resolveOutlookUserInfo({
+            clientInfo: { name: 42, preferred_username: 'not-an-address' },
+            idTokenPayload: { email: 'also-not-an-address' }
+        });
+
+        assert.equal(userInfo.email, null);
+        assert.equal(userInfo.name, null);
+        assert.deepEqual(userInfo.verifiedIdentities, []);
+    });
+
+    await t.test('tolerates missing and malformed input', () => {
+        for (const sources of [undefined, {}, { clientInfo: null, idTokenPayload: null, profile: null }, { profile: 'nope' }]) {
+            const userInfo = resolveOutlookUserInfo(sources);
+            assert.equal(userInfo.email, null);
+            assert.equal(userInfo.username, null);
+            assert.deepEqual(userInfo.verifiedIdentities, []);
+        }
+    });
+});

--- a/test/tools-test.js
+++ b/test/tools-test.js
@@ -191,13 +191,15 @@ test('Tools utility tests', async t => {
 
     await t.test('getSignedFormDataSync() data can be decoded', async () => {
         const secret = 'test-secret';
-        const opts = { account: 'my-account', name: 'John Doe' };
+        const opts = { account: 'my-account', name: 'John Doe', expectedEmail: 'owner@example.com' };
 
         const result = tools.getSignedFormDataSync(secret, opts);
         const decoded = JSON.parse(Buffer.from(result.data, 'base64url').toString());
 
         assert.strictEqual(decoded.account, 'my-account');
         assert.strictEqual(decoded.name, 'John Doe');
+        // The identity pin has to survive into the blob, otherwise the hosted form has nothing to enforce.
+        assert.strictEqual(decoded.expectedEmail, 'owner@example.com');
     });
 
     await t.test('getSignedFormDataSync() filters empty values', async () => {

--- a/translations/messages.pot
+++ b/translations/messages.pot
@@ -1,10 +1,10 @@
 msgid ""
 msgstr ""
 "Content-Type: text/plain; charset=ascii\n"
-"POT-Creation-Date: 2026-07-30 07:33+0000\n"
+"POT-Creation-Date: 2026-08-03 19:18+0000\n"
 
 #: views/error.hbs:6
-#: workers/api.js:3019
+#: workers/api.js:2888
 msgid "Something went wrong"
 msgstr ""
 
@@ -95,7 +95,7 @@ msgid "Your email address <em>%s</em> was re-subscribed."
 msgstr ""
 
 #: views/unsubscribe.hbs:70
-#: views/accounts/register/imap.hbs:23
+#: views/accounts/register/imap.hbs:25
 msgid "Email address"
 msgstr ""
 
@@ -107,21 +107,25 @@ msgstr ""
 msgid "Enter your full name"
 msgstr ""
 
-#: views/accounts/register/imap.hbs:29
+#: views/accounts/register/imap.hbs:35
+msgid "This setup link is restricted to this email address"
+msgstr ""
+
+#: views/accounts/register/imap.hbs:37
 msgid "Enter your email address"
 msgstr ""
 
-#: views/accounts/register/imap.hbs:33
+#: views/accounts/register/imap.hbs:43
 #: views/accounts/register/imap-server.hbs:39
 #: views/accounts/register/imap-server.hbs:146
 msgid "Password"
 msgstr ""
 
-#: views/accounts/register/imap.hbs:39
+#: views/accounts/register/imap.hbs:49
 msgid "Enter your account password"
 msgstr ""
 
-#: views/accounts/register/imap.hbs:45
+#: views/accounts/register/imap.hbs:55
 msgid "Continue"
 msgstr ""
 
@@ -254,94 +258,99 @@ msgid ""
 "connect your account."
 msgstr ""
 
-#: lib/tools.js:1056
+#: lib/tools.js:1057
 #: lib/ui-routes/unsubscribe-routes.js:28
 #: lib/ui-routes/unsubscribe-routes.js:92
 msgid "Invalid input"
 msgstr ""
 
-#: lib/tools.js:1893
+#: lib/tools.js:1878
 msgid "Signature validation failed"
 msgstr ""
 
-#: lib/tools.js:1916
-#: lib/tools.js:1922
-#: lib/tools.js:1927
-#: lib/ui-routes/account-routes.js:976
+#: lib/tools.js:1901
+#: lib/tools.js:1907
+#: lib/tools.js:1912
+#: lib/ui-routes/account-routes.js:1051
 msgid "Invalid or expired account setup URL"
 msgstr ""
 
-#: lib/ui-routes/account-routes.js:414
-#: lib/ui-routes/account-routes.js:455
-#: lib/ui-routes/account-routes.js:695
-#: lib/ui-routes/account-routes.js:748
-#: lib/ui-routes/account-routes.js:1006
-#: lib/ui-routes/account-routes.js:1098
-#: workers/api.js:2292
-#: workers/api.js:2646
+#: lib/ui-routes/account-routes.js:424
+#: lib/ui-routes/account-routes.js:468
+#: lib/ui-routes/account-routes.js:744
+#: lib/ui-routes/account-routes.js:797
+#: lib/ui-routes/account-routes.js:973
+#: lib/ui-routes/account-routes.js:1081
+#: lib/ui-routes/account-routes.js:1173
+#: workers/api.js:2075
+#: workers/api.js:2142
 msgid "Email Account Setup"
 msgstr ""
 
-#: lib/ui-routes/account-routes.js:480
-#: lib/ui-routes/account-routes.js:512
+#: lib/ui-routes/account-routes.js:493
+#: lib/ui-routes/account-routes.js:525
 #: lib/ui-routes/unsubscribe-routes.js:68
 msgid "Invalid request. Check your input and try again."
 msgstr ""
 
-#: lib/ui-routes/account-routes.js:645
+#: lib/ui-routes/account-routes.js:658
 msgid "Too many attempts for this setup link. Request a new setup link to continue."
 msgstr ""
 
-#: lib/ui-routes/account-routes.js:735
-#: lib/ui-routes/account-routes.js:1035
+#: lib/ui-routes/account-routes.js:694
+msgid "This setup link cannot be used with this email address"
+msgstr ""
+
+#: lib/ui-routes/account-routes.js:784
+#: lib/ui-routes/account-routes.js:1110
 msgid "Couldn't set up account. Try again."
 msgstr ""
 
-#: lib/ui-routes/account-routes.js:818
-#: lib/ui-routes/account-routes.js:829
+#: lib/ui-routes/account-routes.js:867
+#: lib/ui-routes/account-routes.js:878
 #: lib/ui-routes/admin-entities-routes.js:2045
 msgid "Server hostname was not found"
 msgstr ""
 
-#: lib/ui-routes/account-routes.js:821
-#: lib/ui-routes/account-routes.js:832
+#: lib/ui-routes/account-routes.js:870
+#: lib/ui-routes/account-routes.js:881
 #: lib/ui-routes/admin-entities-routes.js:2048
 msgid "Invalid username or password"
 msgstr ""
 
-#: lib/ui-routes/account-routes.js:835
+#: lib/ui-routes/account-routes.js:884
 #: lib/ui-routes/admin-entities-routes.js:2051
 msgid "Authentication credentials were not provided"
 msgstr ""
 
-#: lib/ui-routes/account-routes.js:838
+#: lib/ui-routes/account-routes.js:887
 #: lib/ui-routes/admin-entities-routes.js:2054
 msgid "OAuth2 authentication failed"
 msgstr ""
 
-#: lib/ui-routes/account-routes.js:841
-#: lib/ui-routes/account-routes.js:845
+#: lib/ui-routes/account-routes.js:890
+#: lib/ui-routes/account-routes.js:894
 #: lib/ui-routes/admin-entities-routes.js:2057
 #: lib/ui-routes/admin-entities-routes.js:2061
 msgid "TLS protocol error"
 msgstr ""
 
-#: lib/ui-routes/account-routes.js:849
+#: lib/ui-routes/account-routes.js:898
 #: lib/ui-routes/admin-entities-routes.js:2065
 msgid "Connection timed out"
 msgstr ""
 
-#: lib/ui-routes/account-routes.js:852
+#: lib/ui-routes/account-routes.js:901
 #: lib/ui-routes/admin-entities-routes.js:2068
 msgid "Could not connect to server"
 msgstr ""
 
-#: lib/ui-routes/account-routes.js:855
+#: lib/ui-routes/account-routes.js:904
 #: lib/ui-routes/admin-entities-routes.js:2071
 msgid "Unexpected server response"
 msgstr ""
 
-#: lib/ui-routes/account-routes.js:964
+#: lib/ui-routes/account-routes.js:1039
 msgid "Temporary error, please try again"
 msgstr ""
 
@@ -399,7 +408,7 @@ msgstr ""
 msgid "Couldn't process request. Try again."
 msgstr ""
 
-#: workers/api.js:3018
-#: workers/api.js:3119
+#: workers/api.js:2887
+#: workers/api.js:2988
 msgid "Requested page not found"
 msgstr ""

--- a/views/accounts/edit.hbs
+++ b/views/accounts/edit.hbs
@@ -15,6 +15,7 @@
 
             {{> ui/form-field id="name" label="Full name" value=values.name error=errors.name hint="Full name of the user"}}
             {{> ui/form-field id="email" type="email" label="Email" value=values.email error=errors.email hint="Email address of the user"}}
+            {{> ui/form-field id="expectedEmail" type="email" label="Expected identity" value=values.expectedEmail error=errors.expectedEmail hint="Optional. Setups through the hosted authentication form are rejected unless the identity they authenticate matches this address. Clear the field to remove the restriction."}}
 
         </div>
     </div>

--- a/views/accounts/register/imap.hbs
+++ b/views/accounts/register/imap.hbs
@@ -19,14 +19,24 @@ step (/accounts/new/imap/server). --}}
             <span class="ee-hint">{{_ "Enter your full name" templateLocale }}</span>
         </div>
 
+        {{!-- When the setup link pins an expected address the field is fixed. This is a convenience
+        only: the server rejects a mismatch regardless of what is submitted. --}}
         <div class="ee-field">
             <label class="ee-label" for="email">{{_ "Email address" templateLocale }}</label>
+            {{!-- autofocus only when the field is editable: focusing a readonly input strands the caret --}}
             <input type="email" class="ee-input{{#if errors.email}} ee-invalid{{/if}}" id="email" name="email"
-                value="{{values.email}}" {{#if values.name}}autofocus{{/if}} required />
+                value="{{values.email}}" {{#unless values.emailPinned}}{{#if values.name}}autofocus{{/if}}{{/unless}}
+                {{#if values.emailPinned}}readonly{{/if}} required />
             {{#if errors.email}}
             <span class="ee-field-error">{{errors.email}}</span>
             {{/if}}
-            <span class="ee-hint">{{_ "Enter your email address" templateLocale }}</span>
+            <span class="ee-hint">
+                {{#if values.emailPinned}}
+                {{_ "This setup link is restricted to this email address" templateLocale }}
+                {{else}}
+                {{_ "Enter your email address" templateLocale }}
+                {{/if}}
+            </span>
         </div>
 
         <div class="ee-field">

--- a/workers/api.js
+++ b/workers/api.js
@@ -63,6 +63,15 @@ const pathlib = require('path');
 const crypto = require('crypto');
 const { registeredPublishers, openChangeStream } = require('../lib/response-stream');
 const { oauth2Apps } = require('../lib/oauth2-apps');
+const { decodeJwtPayload } = require('../lib/oauth/decode-jwt-payload');
+const { resolveOutlookUserInfo } = require('../lib/oauth/outlook-identity');
+const {
+    matchesExpectedIdentity,
+    pendingSetupExpectation,
+    resolveExpectedIdentity,
+    buildIdentityMismatchUrl,
+    IDENTITY_MISMATCH_MESSAGE
+} = require('../lib/account/expected-identity');
 
 const handlebars = require('handlebars');
 const AuthBearer = require('hapi-auth-bearer-token');
@@ -2064,6 +2073,29 @@ const init = async () => {
 
             const oAuth2Client = await oauth2Apps.getClient(oauth2App.id);
 
+            // have to use HTML redirect, otherwise samesite=strict cookies are not passed on
+            const renderRedirect = httpRedirectUrl =>
+                h.view(
+                    'redirect',
+                    {
+                        pageTitleFull: request.app.gt.gettext('Email Account Setup'),
+                        httpRedirectUrl
+                    },
+                    {
+                        layout: 'public'
+                    }
+                );
+
+            // Addresses the provider itself returned over a back channel, the only values allowed to
+            // satisfy an expected identity (see lib/account/expected-identity.js). Every provider case
+            // fills this in; one that does not leaves it empty, and an empty list fails the check closed.
+            const providerIdentities = [];
+
+            // The token to revoke if the setup is rejected after the code was already exchanged, set by
+            // each provider case because the token response is scoped to the switch. Prefer the refresh
+            // token: revoking either invalidates the grant, but the access token may already be expired.
+            let grantToken;
+
             // `app.provider` is for example "gmail", `provider` is oauth2 app id
             switch (oauth2App.provider) {
                 case 'gmail': {
@@ -2130,20 +2162,14 @@ const init = async () => {
 
                     // With OpenID Connect scopes (openid, email, profile), the ID token contains user info
                     // This works for all account types including send-only accounts
-                    if (r.id_token && typeof r.id_token === 'string') {
-                        let [, encodedValue] = r.id_token.split('.');
-                        if (encodedValue) {
-                            try {
-                                let decodedValue = JSON.parse(Buffer.from(encodedValue, 'base64url').toString());
-                                if (decodedValue && typeof decodedValue.email === 'string' && isEmail(decodedValue.email)) {
-                                    userEmail = decodedValue.email;
-                                    userName = decodedValue.name || null;
-                                    request.logger.info({ msg: 'Extracted user info from ID token', userEmail, userName });
-                                }
-                            } catch (err) {
-                                request.logger.error({ msg: 'Failed to decode Gmail ID token', err });
-                            }
-                        }
+                    const idTokenPayload = decodeJwtPayload(r.id_token);
+                    if (r.id_token && !idTokenPayload) {
+                        request.logger.error({ msg: 'Failed to decode Gmail ID token' });
+                    }
+                    if (idTokenPayload && typeof idTokenPayload.email === 'string' && isEmail(idTokenPayload.email)) {
+                        userEmail = idTokenPayload.email;
+                        userName = idTokenPayload.name || null;
+                        request.logger.info({ msg: 'Extracted user info from ID token', userEmail, userName });
                     }
 
                     // If ID token didn't provide email, fall back to Gmail API profile endpoint
@@ -2188,6 +2214,11 @@ const init = async () => {
                         throw error;
                     }
 
+                    // Back-channel only: either the id_token from the token endpoint or the Gmail profile
+                    // API response, never a value that travelled through the browser.
+                    providerIdentities.push(userEmail);
+                    grantToken = r.refresh_token || r.access_token;
+
                     accountData.email = isEmail(userEmail) ? userEmail : accountData.email;
 
                     const defaultScopes = (oauth2App.baseScopes && GMAIL_SCOPES[oauth2App.baseScopes]) || GMAIL_SCOPES.imap;
@@ -2222,43 +2253,31 @@ const init = async () => {
                         throw error;
                     }
 
-                    let userInfo = {};
+                    let userInfo;
 
                     if (!oauth2App.baseScopes || oauth2App.baseScopes === 'imap') {
-                        // Read account info from GET arguments
-                        // This is needed because previously EmailEngine did not request for the User.Read scope
+                        // Read account info from the id_token, falling back to the client_info GET argument.
+                        // The fallback is needed because previously EmailEngine did not request for the
+                        // User.Read scope - but client_info arrives through the browser, so it is a display
+                        // fallback only and never counts as identity evidence. See lib/oauth/outlook-identity.js.
 
-                        let clientInfo = request.query.client_info ? JSON.parse(Buffer.from(request.query.client_info, 'base64url').toString()) : false;
-
-                        if (clientInfo && typeof clientInfo.name === 'string') {
-                            userInfo.name = clientInfo.name;
-                        }
-
-                        if (clientInfo && clientInfo.preferred_username && isEmail(clientInfo.preferred_username)) {
-                            userInfo.email = clientInfo.preferred_username;
-                        }
-
-                        if (r.id_token && typeof r.id_token === 'string') {
-                            let [, encodedValue] = r.id_token.split('.');
-                            if (encodedValue) {
-                                try {
-                                    let decodedValue = JSON.parse(Buffer.from(encodedValue, 'base64url').toString());
-                                    if (decodedValue && typeof decodedValue.name === 'string') {
-                                        userInfo.name = decodedValue.name;
-                                    }
-
-                                    if (decodedValue && typeof decodedValue.email === 'string' && isEmail(decodedValue.email)) {
-                                        userInfo.email = decodedValue.email;
-                                    }
-
-                                    if (decodedValue && typeof decodedValue.preferred_username === 'string' && isEmail(decodedValue.preferred_username)) {
-                                        userInfo.username = decodedValue.preferred_username;
-                                    }
-                                } catch (err) {
-                                    request.logger.error({ msg: 'Failed to decode JWT payload', err, encodedValue });
-                                }
+                        let clientInfo = false;
+                        if (request.query.client_info) {
+                            try {
+                                clientInfo = JSON.parse(Buffer.from(request.query.client_info, 'base64url').toString());
+                            } catch (err) {
+                                // Base64-shaped but not JSON. It is an optional display hint, so log and continue
+                                // rather than failing the whole setup on a value we do not trust anyway.
+                                request.logger.warn({ msg: 'Failed to decode Outlook client_info argument', err });
                             }
                         }
+
+                        const idTokenPayload = decodeJwtPayload(r.id_token);
+                        if (r.id_token && !idTokenPayload) {
+                            request.logger.error({ msg: 'Failed to decode JWT payload' });
+                        }
+
+                        userInfo = resolveOutlookUserInfo({ clientInfo, idTokenPayload });
                     } else {
                         // Request profile info from API
 
@@ -2275,28 +2294,14 @@ const init = async () => {
                             throw err;
                         }
 
+                        userInfo = resolveOutlookUserInfo({ profile: profileRes });
+
                         request.logger.info({
                             msg: 'User profile returned by MS Graph API',
                             user: userInfo.email,
                             provider: oauth2App.provider,
                             profile: profileRes
                         });
-
-                        if (profileRes.displayName) {
-                            userInfo.name = profileRes.displayName;
-                        }
-
-                        if (profileRes.mail) {
-                            userInfo.email = profileRes.mail;
-                        }
-
-                        if (profileRes.userPrincipalName) {
-                            userInfo.username = profileRes.userPrincipalName;
-                        }
-                    }
-
-                    if (!userInfo.email && userInfo.username && isEmail(userInfo.username)) {
-                        userInfo.email = userInfo.username;
                     }
 
                     const authData = {
@@ -2307,6 +2312,10 @@ const init = async () => {
                         let error = Boom.boomify(new Error(`Oauth failed: failed to retrieve account email address`), { statusCode: 400 });
                         throw error;
                     }
+
+                    // Only the back-channel addresses, so a forged client_info cannot satisfy an expectation.
+                    providerIdentities.push(...userInfo.verifiedIdentities);
+                    grantToken = r.refresh_token || r.access_token;
 
                     if (accountData.oauth2 && accountData.oauth2.auth && accountData.oauth2.auth.delegatedUser) {
                         // Delegated user (shared mailbox) specified in oauth2.auth.delegatedUser
@@ -2369,6 +2378,10 @@ const init = async () => {
                         throw error;
                     }
 
+                    // Back-channel only: the Mail.ru userinfo endpoint response.
+                    providerIdentities.push(profileRes.email);
+                    grantToken = r.refresh_token || r.access_token;
+
                     accountData.name = accountData.name || profileRes.name || '';
                     accountData.email = isEmail(profileRes.email) ? profileRes.email : accountData.email;
 
@@ -2396,6 +2409,52 @@ const init = async () => {
                 default: {
                     throw new Error('Unknown OAuth2 provider');
                 }
+            }
+
+            // Expected identity check. Runs before the nonce claim and before create(), so a rejected
+            // setup neither consumes the signed link nor overwrites the credentials already on the
+            // account. The expectation can come from the signed form blob or from the account itself -
+            // persisting it is what makes the constraint outlive the link that introduced it, and it is
+            // why a later link issued without expectedEmail cannot quietly drop the pin.
+            const expectedEmail = await resolveExpectedIdentity(redis, {
+                account: accountData.account,
+                blobExpectation: pendingSetupExpectation(accountData, accountMeta)
+            });
+
+            if (expectedEmail && !matchesExpectedIdentity(expectedEmail, providerIdentities)) {
+                // Neither address is logged: the expectation and the authenticated identity both belong to
+                // the end user, and this line is the one record of a failed attempt. Note the provider
+                // identity was already logged by the "Provisioned OAuth2 tokens" line above.
+                request.logger.warn({
+                    msg: 'OAuth2 identity did not match the expected email address',
+                    account: accountData.account,
+                    provider: oauth2App.provider
+                });
+
+                // The code was already exchanged, so we are holding a refresh token we will never use.
+                // Best effort, and the same duck-typing guard Account.delete({ revoke }) uses: only
+                // GmailOauth implements revokeToken, and a rejected setup must not become a 500.
+                if (grantToken && typeof oAuth2Client.revokeToken === 'function') {
+                    try {
+                        await oAuth2Client.revokeToken(grantToken);
+                    } catch (err) {
+                        request.logger.error({ msg: 'Failed to revoke the OAuth2 grant after an identity mismatch', err });
+                    }
+                }
+
+                if (redirectUrl) {
+                    return renderRedirect(buildIdentityMismatchUrl(redirectUrl, await settings.get('serviceUrl'), accountData.account));
+                }
+
+                let error = Boom.boomify(new Error(IDENTITY_MISMATCH_MESSAGE), { statusCode: 403 });
+                error.output.payload.code = 'AccountIdentityMismatch';
+                throw error;
+            }
+
+            if (expectedEmail) {
+                // Pin the account so every later setup is checked, including one driven by a link that
+                // carries no expectation of its own.
+                accountData.expectedEmail = expectedEmail;
             }
 
             if ('delegated' in accountData) {
@@ -2463,17 +2522,7 @@ const init = async () => {
                 httpRedirectUrl = `/admin/accounts/${result.account}`;
             }
 
-            // have to use HTML redirect, otherwise samesite=strict cookies are not passed on
-            return h.view(
-                'redirect',
-                {
-                    pageTitleFull: request.app.gt.gettext('Email Account Setup'),
-                    httpRedirectUrl
-                },
-                {
-                    layout: 'public'
-                }
-            );
+            return renderRedirect(httpRedirectUrl);
         },
         options: {
             description: 'OAuth2 response endpoint',
@@ -2504,7 +2553,9 @@ const init = async () => {
                         .description('OAuth2 scopes'),
                     client_info: Joi.string()
                         .empty('')
-                        .max(1024 * 1024)
+                        // A few hundred bytes of JSON in practice. Bounded tightly because this is an
+                        // unauthenticated route and the value is JSON.parse-d.
+                        .max(4 * 1024)
                         .base64({ urlSafe: true, paddingRequired: false })
                         .description('Outlook client info'),
                     error: Joi.string()


### PR DESCRIPTION
Implements the expected-identity constraint proposed in #626, with a different design and two fixes found along the way. #626 can be closed in favour of this.

## What it does

Adds an optional `expectedEmail` to accounts. A hosted authentication form setup is rejected before any credentials are stored unless the identity it authenticates matches the pinned address. Set it through `POST /v1/authentication/form`, `POST /v1/account` or `PUT /v1/account/{account}`; clear it with `null` or from the account edit page.

Without it, whoever completes an interactive setup decides which mailbox the account ends up bound to: `Account.create()` overwrites `oauth2.auth.user` on an existing account with no identity check, so a reconnect could silently rebind someone else's account to a different mailbox.

## Design notes

- **Persisted on the account**, not just on the link that introduced it, so it also applies to a later link issued without one and to admin re-authentication. A freshly signed link carrying its own expectation wins over the stored one, which is what leaves a legitimate mailbox migration a way through.
- **Both arms enforce it**, so the constraint cannot be sidestepped by picking the IMAP tab on a form that also offers OAuth2.
- **The guarantee differs per arm and is documented as such.** On OAuth2 the provider vouches for the identity. On IMAP the only evidence is the address typed into the form, which the credentials beside it do not prove ownership of, so the guarantee there is "the account is registered under the expected address", not "the account holds that mailbox".
- **No gate inside `Account.create()`** on purpose: it is reached by authenticated paths where enforcement is wrong, and it only sees `oauth2.auth.user`, so an MS365 pin on the mailbox address rather than the UPN would be falsely rejected.
- On mismatch the grant is revoked best-effort, and the integrator gets `error=account_identity_mismatch` on the redirect (both arms).

## Two fixes found while building this

**The Microsoft callback treated `client_info` as identity evidence.** That blob arrives as an unsigned query parameter through the browser, and because the Outlook scope sets never request the OIDC `email` scope, the id_token normally carries no `email` claim to override it. A forged value therefore survived as the account's stored address and default `From`, and would have satisfied the new constraint. Identity resolution moves to `lib/oauth/outlook-identity.js`, where only back-channel values count as evidence. Also guards the unchecked `JSON.parse` of `client_info` and bounds its size.

**`Account.update()` issued `hmset` with no field/value pairs** whenever a payload serialized to nothing, which Redis rejects, so an empty `PUT` returned 500.

## Testing

- Unit tier 1908/1908, including new suites for the Microsoft trust boundary, the identity comparison and precedence rules, and the JWT payload decode.
- Hosted-form integration suite 23/23, covering: a matching address is accepted and pinned; a mismatch is rejected **and no account is created**; a stored pin applies to a link carrying no expectation; clearing via the API lets the same submission through; the documented redirect contract.
- OpenAPI golden re-recorded (four new schema entries).
- Lint, format and gettext catalog clean.

Not covered automatically: replaying a Microsoft callback with a forged `client_info` against a real `baseScopes: 'imap'` app. Worth doing manually on the test instance.