### PR TITLE
fix(accounts): let a wrong-account setup be retried instead of bouncing it back

### DIFF
--- a/lib/account/expected-identity.js
+++ b/lib/account/expected-identity.js
@@ -14,8 +14,9 @@ const { REDIS_PREFIX } = require('../consts');
 // address", not "the account holds that mailbox". Do not restate it more strongly than that.
 //
 // Everything the two arms must agree on lives here - where the expectation is read from, which one wins,
-// what counts as a match, and the error contract - because the arms are 1500 lines apart in different
-// workers and any of those drifting is a silently weaker constraint.
+// and what counts as a match - because the arms are 1500 lines apart in different workers and any of
+// those drifting is a silently weaker constraint. How a rejection is PRESENTED is deliberately not here:
+// both arms render views/account-identity-error.hbs, but only each arm knows where "try again" leads.
 //
 // What counts as EVIDENCE is the one thing each arm supplies itself, because it genuinely differs:
 //
@@ -25,11 +26,6 @@ const { REDIS_PREFIX } = require('../consts');
 //   IMAP   - the address submitted on the form. The credentials still have to authenticate against the
 //            server, but nothing proves the address belongs to that mailbox, so the guarantee is the
 //            weaker "the account is registered under the expected address".
-
-// The error contract published in the POST /v1/authentication/form notes. Integrators match on this
-// string, so it is a public interface - keep it and the description together and in one place.
-const IDENTITY_MISMATCH_ERROR = 'account_identity_mismatch';
-const IDENTITY_MISMATCH_MESSAGE = 'Authenticated account does not match the expected email address';
 
 function normalizeEmail(value) {
     return typeof value === 'string' ? value.trim().toLowerCase() : '';
@@ -89,23 +85,4 @@ async function resolveExpectedIdentity(redis, opts) {
     return normalizeEmail(await redis.hget(`${REDIS_PREFIX}iad:${account}`, 'expectedEmail')) || null;
 }
 
-// The redirect an integrator gets when the setup is rejected. Deliberately carries no `state`: nothing
-// was created, so there is no account state to report.
-function buildIdentityMismatchUrl(redirectUrl, serviceUrl, account) {
-    const url = new URL(redirectUrl, serviceUrl);
-    if (account) {
-        url.searchParams.set('account', account);
-    }
-    url.searchParams.set('error', IDENTITY_MISMATCH_ERROR);
-    url.searchParams.set('error_description', IDENTITY_MISMATCH_MESSAGE);
-    return url.href;
-}
-
-module.exports = {
-    normalizeEmail,
-    matchesExpectedIdentity,
-    pendingSetupExpectation,
-    resolveExpectedIdentity,
-    buildIdentityMismatchUrl,
-    IDENTITY_MISMATCH_MESSAGE
-};
+module.exports = { normalizeEmail, matchesExpectedIdentity, pendingSetupExpectation, resolveExpectedIdentity };

--- a/lib/api-routes/account-routes.js
+++ b/lib/api-routes/account-routes.js
@@ -1433,7 +1433,7 @@ async function init(args) {
             description: 'Generate authentication link',
             notes: [
                 'Generates a redirect link to the hosted authentication form',
-                'If `expectedEmail` is set and the user completes the form as a different identity, the setup is rejected before any credentials are stored, and the user is sent to `redirectUrl` with `error=account_identity_mismatch` and an `error_description` instead of the usual `account` and `state` arguments.'
+                'If `expectedEmail` is set and the user completes the form as a different identity, the setup is rejected before any credentials are stored. The user stays on EmailEngine, which names both addresses and offers to restart the setup, so the browser is never redirected to `redirectUrl`.'
             ],
             tags: ['api', 'Account'],
 

--- a/lib/oauth/retry-setup.js
+++ b/lib/oauth/retry-setup.js
@@ -1,0 +1,38 @@
+'use strict';
+
+// Builds the pending-setup record for a retry after an OAuth2 attempt the user can correct themselves -
+// a consent screen with permissions unchecked, or signing in as an account the setup link is not pinned
+// to. The retry is a fresh single-use setup, so it needs a record of its own.
+//
+// The subtlety is which parts of the rejected attempt to carry over. By the time either failure is
+// detected, the provider branches have already rewritten accountData from whoever actually signed in:
+// `email` holds the authenticated address, `name` may hold their display name, and `oauth2` holds their
+// tokens. Copying that wholesale would let a rejected identity leak into the account the retry creates,
+// while rebuilding from scratch would drop what the caller actually asked for.
+//
+// So the tokens go, and the caller's own intent comes back:
+//
+//   oauth2.auth.delegatedUser - names the MAILBOX TO BIND, not a credential. Dropping it silently turns a
+//                               shared-mailbox setup into a personal one, so the retry would bind the
+//                               principal's own mailbox while reporting success.
+//   email                     - for a delegated setup this is the shared mailbox, and both delegation
+//                               paths in the Outlook branch key on it. Overwriting it with the address
+//                               the user is being steered towards breaks them.
+//   name                      - filled in from the signed-in profile when the caller supplied none, and
+//                               kept by `name || profile.name` on the retry, so the rejected user's
+//                               display name would stick to the account and become its From name.
+//
+// `_meta` rides along unchanged: it carries the redirect URL, the expected identity and the single-use
+// form nonce, which is claimed only on success and so is still unspent here.
+function buildRetrySetup(accountData, requestedSetup, provider, accountMeta) {
+    const { email, name, delegatedUser } = requestedSetup || {};
+
+    return Object.assign({}, accountData, {
+        oauth2: delegatedUser ? { provider, auth: { delegatedUser } } : { provider },
+        email,
+        name,
+        _meta: accountMeta
+    });
+}
+
+module.exports = { buildRetrySetup };

--- a/lib/ui-routes/account-routes.js
+++ b/lib/ui-routes/account-routes.js
@@ -42,8 +42,8 @@ const {
     ACCOUNT_DISPLAY_STATES,
     signedFormBlobFields: signedBlobFields
 } = require('../schemas');
-const { formatAccountData, cachedTemplates, ACCOUNT_STATE_DISPLAY } = require('./route-helpers');
-const { matchesExpectedIdentity, resolveExpectedIdentity, buildIdentityMismatchUrl } = require('../account/expected-identity');
+const { formatAccountData, cachedTemplates, identityErrorView, ACCOUNT_STATE_DISPLAY } = require('./route-helpers');
+const { matchesExpectedIdentity, resolveExpectedIdentity } = require('../account/expected-identity');
 
 const { REDIS_PREFIX, DEFAULT_PAGE_SIZE, NONCE_BYTES, MAX_FORM_TTL, MAX_FORM_PROBE_ATTEMPTS } = consts;
 
@@ -682,19 +682,27 @@ function init(args) {
     // the constraint would be trivially sidestepped by choosing the IMAP tab on a form that also offers
     // OAuth2.
     //
-    // Returns { expectedEmail, matched } rather than throwing, because the two call sites reject
-    // differently: the account-creating endpoint owes the integrator the documented redirect, while the
-    // mid-flow page-1 step must not eject the user from the form over a correctable typo.
+    // Returns { expectedEmail, matched } rather than throwing so the caller can name the address that was
+    // actually used when it reports the rejection.
     const checkExpectedIdentity = async (data, submittedEmail) => {
         const expectedEmail = await resolveFormExpectation(data);
         return { expectedEmail, matched: !expectedEmail || matchesExpectedIdentity(expectedEmail, [submittedEmail]) };
     };
 
-    const identityMismatchError = gt => {
-        let error = Boom.boomify(new Error(gt.gettext('This setup link cannot be used with this email address')), { statusCode: 403 });
-        error.output.payload.code = 'AccountIdentityMismatch';
-        return error;
-    };
+    // Stop the flow with a way back rather than a redirect to the calling application: entering the wrong
+    // address is correctable, and the hosted form only ever redirects on success. The OAuth arm renders
+    // the same view (workers/api.js), differing only in where "try again" points.
+    //
+    // type=imap keeps the user on the arm they already chose: without it /accounts/new re-asks the
+    // provider question and offers OAuth apps they passed over. The signed blob is still unspent (the
+    // nonce is claimed only on success), so the link works, and the form it returns to prefills the
+    // pinned address read-only.
+    const renderIdentityError = (request, h, expectedEmail, actualEmail) =>
+        identityErrorView(request, h, {
+            expectedEmail,
+            actualEmail,
+            retryUrl: `/accounts/new?data=${encodeURIComponent(request.payload.data)}&sig=${encodeURIComponent(request.payload.sig)}&type=imap`
+        });
 
     // have to use HTML redirect, otherwise samesite=strict cookies are not passed on
     const renderRedirect = (request, h, httpRedirectUrl) =>
@@ -718,13 +726,11 @@ function init(args) {
             // leaked signed link cannot drive unlimited outbound probes to arbitrary domains.
             const data = await authorizeSignedProbe(request.payload, request.app.gt, request.logger);
 
-            // Reject a pinned link early, before autodiscovery runs against the submitted domain. The
-            // authoritative check is on the create endpoint below; this one exists so the user finds out
-            // before typing a password. No redirect here - this is a mid-flow step, and the form prefills
-            // the pinned address, so reaching it with a mismatch means a hand-crafted request.
-            const identity = await checkExpectedIdentity(data, request.payload.email);
-            if (!identity.matched) {
-                throw identityMismatchError(request.app.gt);
+            // Reject a pinned link early, before autodiscovery runs against the submitted domain, so the
+            // user finds out before typing a password. The create endpoint below is the authoritative check.
+            const { expectedEmail, matched } = await checkExpectedIdentity(data, request.payload.email);
+            if (!matched) {
+                return renderIdentityError(request, h, expectedEmail, request.payload.email);
             }
 
             let serverSettings;
@@ -971,16 +977,11 @@ function init(args) {
         async handler(request, h) {
             const data = await parseSignedFormData(redis, request.payload, request.app.gt, { requireNonce: true });
 
-            // Before the nonce claim below, so a rejected attempt does not consume the setup link. This is
-            // the terminal step, so a mismatch owes the integrator the documented redirect
-            // (error=account_identity_mismatch) rather than an EmailEngine error page - the same contract
-            // the OAuth callback honors.
+            // Before the nonce claim below, so a rejected attempt does not consume the setup link and the
+            // "try again" link on the error page still works.
             const { expectedEmail, matched } = await checkExpectedIdentity(data, request.payload.email);
             if (!matched) {
-                if (!data.redirectUrl) {
-                    throw identityMismatchError(request.app.gt);
-                }
-                return renderRedirect(request, h, buildIdentityMismatchUrl(data.redirectUrl, await settings.get('serviceUrl'), data.account));
+                return renderIdentityError(request, h, expectedEmail, request.payload.email);
             }
 
             const accountData = {

--- a/lib/ui-routes/route-helpers.js
+++ b/lib/ui-routes/route-helpers.js
@@ -336,8 +336,36 @@ function jsonErrorPayload(err) {
     return { success: false, error: err.code || 'Error', message: err.message };
 }
 
+// The "wrong account" page, shown when a setup link pinned to one address is completed as another.
+// Rendered from both arms of the hosted form - the OAuth2 callback in workers/api.js and the IMAP arm in
+// ./account-routes.js - which live in different workers, so the view name, the layout and the refusal
+// status are kept here rather than written out twice. Only `retryUrl` is arm-specific: the OAuth arm
+// sends the user back to the provider, the IMAP arm back to the form.
+//
+// 403 rather than the 200 that the sibling views/oauth-scope-error.hbs returns: this is a refused
+// request, the surrounding refusals in the same flow already answer 403, and both call sites are plain
+// form navigations, so the browser still renders the page.
+function identityErrorView(request, h, { expectedEmail, actualEmail, retryUrl }) {
+    return h
+        .view(
+            'account-identity-error',
+            {
+                pageTitleFull: request.app.gt.gettext('Email Account Setup'),
+                templateLocale: request.app.locale,
+                expectedEmail,
+                actualEmail,
+                retryUrl
+            },
+            {
+                layout: 'public'
+            }
+        )
+        .code(403);
+}
+
 module.exports = {
     jsonErrorPayload,
+    identityErrorView,
     OPEN_AI_MODELS,
     cachedTemplates,
     getOpenAiModels,

--- a/static/css/public.css
+++ b/static/css/public.css
@@ -874,6 +874,9 @@ dialog.ee-modal.ee-modal-wide {
 .ee-dl dd {
     margin: 0 0 0.5rem;
     min-width: 0;
+    /* Values here can be email addresses, which offer no natural break opportunity and would otherwise
+       run past the single-column grid on a narrow screen. */
+    overflow-wrap: anywhere;
 }
 
 @media (min-width: 640px) {

--- a/test/expected-identity-test.js
+++ b/test/expected-identity-test.js
@@ -6,13 +6,7 @@
 const test = require('node:test');
 const assert = require('node:assert').strict;
 
-const {
-    normalizeEmail,
-    matchesExpectedIdentity,
-    pendingSetupExpectation,
-    resolveExpectedIdentity,
-    buildIdentityMismatchUrl
-} = require('../lib/account/expected-identity');
+const { normalizeEmail, matchesExpectedIdentity, pendingSetupExpectation, resolveExpectedIdentity } = require('../lib/account/expected-identity');
 
 test('matchesExpectedIdentity()', async t => {
     await t.test('matches case-insensitively and ignores surrounding whitespace', () => {
@@ -125,25 +119,6 @@ test('pendingSetupExpectation()', async t => {
         assert.equal(pendingSetupExpectation({ account: 'acc' }, {}), null);
         assert.equal(pendingSetupExpectation(null, null), null);
         assert.equal(pendingSetupExpectation(), null);
-    });
-});
-
-test('buildIdentityMismatchUrl()', async t => {
-    await t.test('carries the documented error contract and no state', () => {
-        const href = buildIdentityMismatchUrl('https://app.example.com/done', 'https://ee.example.com', 'acc1');
-        const url = new URL(href);
-
-        assert.equal(url.searchParams.get('error'), 'account_identity_mismatch');
-        assert.ok(url.searchParams.get('error_description'), 'integrators are told why');
-        assert.equal(url.searchParams.get('account'), 'acc1');
-        // Nothing was created, so there is no account state to report.
-        assert.equal(url.searchParams.get('state'), null);
-    });
-
-    await t.test('resolves a relative redirect against the service URL and omits an unknown account', () => {
-        const href = buildIdentityMismatchUrl('/done', 'https://ee.example.com', null);
-        assert.equal(new URL(href).origin, 'https://ee.example.com');
-        assert.equal(new URL(href).searchParams.get('account'), null);
     });
 });
 

--- a/test/fixtures/openapi-golden.json
+++ b/test/fixtures/openapi-golden.json
@@ -16617,7 +16617,7 @@
       "post": {
         "summary": "Generate authentication link",
         "operationId": "postV1AuthenticationForm",
-        "description": "Generates a redirect link to the hosted authentication form<br/><br/>If `expectedEmail` is set and the user completes the form as a different identity, the setup is rejected before any credentials are stored, and the user is sent to `redirectUrl` with `error=account_identity_mismatch` and an `error_description` instead of the usual `account` and `state` arguments.",
+        "description": "Generates a redirect link to the hosted authentication form<br/><br/>If `expectedEmail` is set and the user completes the form as a different identity, the setup is rejected before any credentials are stored. The user stays on EmailEngine, which names both addresses and offers to restart the setup, so the browser is never redirected to `redirectUrl`.",
         "parameters": [
           {
             "name": "x-ee-timeout",

--- a/test/integration/hosted-form-test.js
+++ b/test/integration/hosted-form-test.js
@@ -18,6 +18,7 @@ require('dotenv').config({ quiet: true });
 
 const config = require('@zone-eu/wild-config');
 const supertest = require('supertest');
+const he = require('he');
 const crypto = require('node:crypto');
 const test = require('node:test');
 const assert = require('node:assert').strict;
@@ -287,22 +288,26 @@ test('Hosted form enforces the expected account identity on the IMAP arm', async
         assert.equal(acct.status, 404, 'the rejected setup must not have created an account');
     });
 
-    await t.test('a rejection with a redirectUrl honors the documented error contract', async () => {
-        // POST /v1/authentication/form documents error=account_identity_mismatch on the redirect. That
-        // promise is made for the whole form, so the IMAP arm has to keep it too, not just the OAuth arm.
-        const account = `identity-redirect-${crypto.randomBytes(6).toString('hex')}`;
+    await t.test('the rejection names both addresses and offers a way back', async () => {
+        // The user picked the wrong account, which is correctable, so the flow stops on an error page with
+        // a retry link rather than redirecting to the calling application - the hosted form only ever
+        // redirects on success. Naming both addresses is what lets someone spot a near-miss, since the
+        // comparison is exact.
+        const account = `identity-retry-${crypto.randomBytes(6).toString('hex')}`;
         const res = await submit(
             { account, expectedEmail: 'owner@example.com', redirectUrl: 'https://example.com/done' },
             { email: 'someone-else@example.com' }
         );
 
-        assert.equal(res.status, 200, `expected a redirect page, got ${res.status}: ${res.text}`);
-        assert.match(res.text, /error=account_identity_mismatch/, 'the redirect must carry the documented error code');
-        assert.match(res.text, /error_description=/, 'the redirect must explain why');
-        assert.ok(!/[?&]state=/.test(res.text), 'nothing was created, so no account state may be reported');
-
-        const acct = await authed.get(`/v1/account/${account}`);
-        assert.equal(acct.status, 404, 'the rejected setup must not have created an account');
+        assert.equal(res.status, 403, `expected the error page, got ${res.status}: ${res.text}`);
+        // Handlebars entity-escapes the `=` inside the href, so compare against the decoded markup.
+        const html = he.decode(res.text);
+        assert.match(html, /owner@example\.com/, 'the page must name the expected address');
+        assert.match(html, /someone-else@example\.com/, 'the page must name the address that was used');
+        // The blob is still unspent (the nonce is claimed after this check), so the retry link works.
+        // type=imap keeps the user on the arm they chose instead of re-asking the provider question.
+        assert.match(html, /href="\/accounts\/new\?data=[^"]+&sig=[^"]+&type=imap"/, 'the page must offer a way back into the form they were on');
+        assert.ok(!/example\.com\/done/.test(html), 'a rejected setup must not redirect to the calling application');
     });
 
     await t.test('a stored pin applies to a link that carries no expectation of its own', async () => {

--- a/test/retry-setup-test.js
+++ b/test/retry-setup-test.js
@@ -1,0 +1,92 @@
+'use strict';
+
+// Tests for lib/oauth/retry-setup.js.
+//
+// The property under test is what a retry INHERITS from the attempt that was rejected. By the time a
+// retry is offered, the provider branches have rewritten the pending record from whoever actually signed
+// in, so carrying that forward binds the wrong mailbox or keeps the wrong name, while rebuilding from
+// scratch drops what the caller asked for. Both are silent - the retry reports success either way.
+
+const test = require('node:test');
+const assert = require('node:assert').strict;
+
+const { buildRetrySetup } = require('../lib/oauth/retry-setup');
+
+// Shaped like accountData at the point a rejection is detected: the caller's fields already overwritten
+// with the rejected identity, and that identity's tokens attached.
+const rejectedAttempt = extra =>
+    Object.assign(
+        {
+            account: 'acc1',
+            email: 'wrong-person@example.com',
+            name: 'Wrong Person',
+            oauth2: {
+                provider: 'app-id',
+                accessToken: 'ACCESS',
+                refreshToken: 'REFRESH',
+                auth: { user: 'wrong-person@example.com' }
+            }
+        },
+        extra
+    );
+
+test('buildRetrySetup()', async t => {
+    await t.test('drops the tokens the rejected attempt obtained', () => {
+        const retry = buildRetrySetup(rejectedAttempt(), { email: 'owner@example.com' }, 'app-id', {});
+
+        assert.deepEqual(retry.oauth2, { provider: 'app-id' });
+        assert.equal(retry.oauth2.accessToken, undefined);
+        assert.equal(retry.oauth2.refreshToken, undefined);
+    });
+
+    await t.test('keeps a delegated mailbox target, which names a mailbox rather than a credential', () => {
+        // Losing this turns a shared-mailbox setup into a personal one: the retry would bind the
+        // principal's own mailbox and report success.
+        const retry = buildRetrySetup(rejectedAttempt(), { email: 'support@corp.com', name: 'Support', delegatedUser: 'support@corp.com' }, 'app-id', {});
+
+        assert.equal(retry.oauth2.auth.delegatedUser, 'support@corp.com');
+        assert.equal(retry.oauth2.provider, 'app-id');
+        assert.equal(retry.oauth2.accessToken, undefined, 'the delegation target must not drag the tokens back in');
+        // Both Outlook delegation paths key on email, so the shared mailbox has to survive too.
+        assert.equal(retry.email, 'support@corp.com');
+    });
+
+    await t.test('restores the caller fields the rejected identity had overwritten', () => {
+        const retry = buildRetrySetup(rejectedAttempt(), { email: 'owner@example.com', name: 'Owner' }, 'app-id', {});
+
+        assert.equal(retry.email, 'owner@example.com');
+        assert.equal(retry.name, 'Owner');
+    });
+
+    await t.test('leaves the fields empty when the caller supplied none', () => {
+        // Rather than inheriting the rejected user's address and display name, which would otherwise stick
+        // to the account and become its outgoing From name.
+        const retry = buildRetrySetup(rejectedAttempt(), {}, 'app-id', {});
+
+        assert.equal(retry.email, undefined);
+        assert.equal(retry.name, undefined);
+    });
+
+    await t.test('carries _meta through unchanged so the setup keeps its identity pin and nonce', () => {
+        const accountMeta = { redirectUrl: 'https://app.example.com/done', expectedEmail: 'owner@example.com', n: 'nonce', t: 1 };
+        const retry = buildRetrySetup(rejectedAttempt(), { email: 'owner@example.com' }, 'app-id', accountMeta);
+
+        assert.deepEqual(retry._meta, accountMeta);
+    });
+
+    await t.test('preserves unrelated account fields and does not mutate the input', () => {
+        const attempt = rejectedAttempt({ delegated: true, notifyFrom: '2026-01-01T00:00:00.000Z' });
+        const retry = buildRetrySetup(attempt, { email: 'support@corp.com' }, 'app-id', {});
+
+        assert.equal(retry.delegated, true);
+        assert.equal(retry.notifyFrom, '2026-01-01T00:00:00.000Z');
+        assert.equal(retry.account, 'acc1');
+        assert.equal(attempt.email, 'wrong-person@example.com', 'the caller keeps using accountData afterwards');
+        assert.equal(attempt.oauth2.accessToken, 'ACCESS');
+    });
+
+    await t.test('tolerates a missing requestedSetup', () => {
+        const retry = buildRetrySetup(rejectedAttempt(), undefined, 'app-id', {});
+        assert.deepEqual(retry.oauth2, { provider: 'app-id' });
+    });
+});

--- a/translations/messages.pot
+++ b/translations/messages.pot
@@ -1,10 +1,17 @@
 msgid ""
 msgstr ""
 "Content-Type: text/plain; charset=ascii\n"
-"POT-Creation-Date: 2026-08-03 19:18+0000\n"
+"POT-Creation-Date: 2026-08-03 20:37+0000\n"
+
+#: views/config/license.hbs:20
+#: lib/ui-routes/oauth-config-routes.js:217
+msgid "%d day"
+msgid_plural "%d days"
+msgstr[0] ""
+msgstr[1] ""
 
 #: views/error.hbs:6
-#: workers/api.js:2888
+#: workers/api.js:2902
 msgid "Something went wrong"
 msgstr ""
 
@@ -20,39 +27,8 @@ msgstr ""
 msgid "Dashboard"
 msgstr ""
 
-#: views/config/license.hbs:20
-#: lib/ui-routes/oauth-config-routes.js:217
-msgid "%d day"
-msgid_plural "%d days"
-msgstr[0] ""
-msgstr[1] ""
-
 #: views/redirect.hbs:1
 msgid "Click <a href=\"%s\">here</a> to continue&mldr;"
-msgstr ""
-
-#: views/oauth-scope-error.hbs:5
-msgid "Insufficient Permissions"
-msgstr ""
-
-#: views/oauth-scope-error.hbs:10
-msgid ""
-"All requested permissions are required for this service to function "
-"properly. Some required permissions were not granted during sign-in."
-msgstr ""
-
-#: views/oauth-scope-error.hbs:14
-msgid "The following permissions were not granted:"
-msgstr ""
-
-#: views/oauth-scope-error.hbs:23
-msgid ""
-"Please try again and make sure all permission checkboxes are selected on "
-"the Google consent screen."
-msgstr ""
-
-#: views/oauth-scope-error.hbs:28
-msgid "Try Again"
 msgstr ""
 
 #: views/unsubscribe.hbs:7
@@ -99,6 +75,31 @@ msgstr ""
 msgid "Email address"
 msgstr ""
 
+#: views/oauth-scope-error.hbs:5
+msgid "Insufficient Permissions"
+msgstr ""
+
+#: views/oauth-scope-error.hbs:10
+msgid ""
+"All requested permissions are required for this service to function "
+"properly. Some required permissions were not granted during sign-in."
+msgstr ""
+
+#: views/oauth-scope-error.hbs:14
+msgid "The following permissions were not granted:"
+msgstr ""
+
+#: views/oauth-scope-error.hbs:23
+msgid ""
+"Please try again and make sure all permission checkboxes are selected on "
+"the Google consent screen."
+msgstr ""
+
+#: views/oauth-scope-error.hbs:28
+#: views/account-identity-error.hbs:30
+msgid "Try Again"
+msgstr ""
+
 #: views/accounts/register/imap.hbs:13
 msgid "Your name"
 msgstr ""
@@ -127,6 +128,14 @@ msgstr ""
 
 #: views/accounts/register/imap.hbs:55
 msgid "Continue"
+msgstr ""
+
+#: views/accounts/register/index.hbs:6
+msgid "Choose your email account provider"
+msgstr ""
+
+#: views/accounts/register/index.hbs:19
+msgid "Standard IMAP"
 msgstr ""
 
 #: views/accounts/register/imap-server.hbs:22
@@ -242,12 +251,28 @@ msgstr ""
 msgid "Request failed."
 msgstr ""
 
-#: views/accounts/register/index.hbs:6
-msgid "Choose your email account provider"
+#: views/account-identity-error.hbs:7
+msgid "Wrong Email Account"
 msgstr ""
 
-#: views/accounts/register/index.hbs:19
-msgid "Standard IMAP"
+#: views/account-identity-error.hbs:12
+msgid ""
+"This setup link can only be used with one specific email account, and a "
+"different one was used."
+msgstr ""
+
+#: views/account-identity-error.hbs:16
+msgid "Expected"
+msgstr ""
+
+#: views/account-identity-error.hbs:19
+msgid "Used"
+msgstr ""
+
+#: views/account-identity-error.hbs:25
+msgid ""
+"Try again and use the expected account. If you believe this is a mistake, "
+"contact the service that sent you this link."
 msgstr ""
 
 #: lib/autodetect-imap-settings.js:90
@@ -271,19 +296,19 @@ msgstr ""
 #: lib/tools.js:1901
 #: lib/tools.js:1907
 #: lib/tools.js:1912
-#: lib/ui-routes/account-routes.js:1051
+#: lib/ui-routes/account-routes.js:1056
 msgid "Invalid or expired account setup URL"
 msgstr ""
 
 #: lib/ui-routes/account-routes.js:424
 #: lib/ui-routes/account-routes.js:468
-#: lib/ui-routes/account-routes.js:744
-#: lib/ui-routes/account-routes.js:797
-#: lib/ui-routes/account-routes.js:973
-#: lib/ui-routes/account-routes.js:1081
-#: lib/ui-routes/account-routes.js:1173
+#: lib/ui-routes/account-routes.js:712
+#: lib/ui-routes/account-routes.js:763
+#: lib/ui-routes/account-routes.js:816
+#: lib/ui-routes/account-routes.js:1169
+#: lib/ui-routes/route-helpers.js:353
 #: workers/api.js:2075
-#: workers/api.js:2142
+#: workers/api.js:2147
 msgid "Email Account Setup"
 msgstr ""
 
@@ -297,60 +322,56 @@ msgstr ""
 msgid "Too many attempts for this setup link. Request a new setup link to continue."
 msgstr ""
 
-#: lib/ui-routes/account-routes.js:694
-msgid "This setup link cannot be used with this email address"
-msgstr ""
-
-#: lib/ui-routes/account-routes.js:784
-#: lib/ui-routes/account-routes.js:1110
+#: lib/ui-routes/account-routes.js:803
+#: lib/ui-routes/account-routes.js:1106
 msgid "Couldn't set up account. Try again."
 msgstr ""
 
-#: lib/ui-routes/account-routes.js:867
-#: lib/ui-routes/account-routes.js:878
+#: lib/ui-routes/account-routes.js:886
+#: lib/ui-routes/account-routes.js:897
 #: lib/ui-routes/admin-entities-routes.js:2045
 msgid "Server hostname was not found"
 msgstr ""
 
-#: lib/ui-routes/account-routes.js:870
-#: lib/ui-routes/account-routes.js:881
+#: lib/ui-routes/account-routes.js:889
+#: lib/ui-routes/account-routes.js:900
 #: lib/ui-routes/admin-entities-routes.js:2048
 msgid "Invalid username or password"
 msgstr ""
 
-#: lib/ui-routes/account-routes.js:884
+#: lib/ui-routes/account-routes.js:903
 #: lib/ui-routes/admin-entities-routes.js:2051
 msgid "Authentication credentials were not provided"
 msgstr ""
 
-#: lib/ui-routes/account-routes.js:887
+#: lib/ui-routes/account-routes.js:906
 #: lib/ui-routes/admin-entities-routes.js:2054
 msgid "OAuth2 authentication failed"
 msgstr ""
 
-#: lib/ui-routes/account-routes.js:890
-#: lib/ui-routes/account-routes.js:894
+#: lib/ui-routes/account-routes.js:909
+#: lib/ui-routes/account-routes.js:913
 #: lib/ui-routes/admin-entities-routes.js:2057
 #: lib/ui-routes/admin-entities-routes.js:2061
 msgid "TLS protocol error"
 msgstr ""
 
-#: lib/ui-routes/account-routes.js:898
+#: lib/ui-routes/account-routes.js:917
 #: lib/ui-routes/admin-entities-routes.js:2065
 msgid "Connection timed out"
 msgstr ""
 
-#: lib/ui-routes/account-routes.js:901
+#: lib/ui-routes/account-routes.js:920
 #: lib/ui-routes/admin-entities-routes.js:2068
 msgid "Could not connect to server"
 msgstr ""
 
-#: lib/ui-routes/account-routes.js:904
+#: lib/ui-routes/account-routes.js:923
 #: lib/ui-routes/admin-entities-routes.js:2071
 msgid "Unexpected server response"
 msgstr ""
 
-#: lib/ui-routes/account-routes.js:1039
+#: lib/ui-routes/account-routes.js:1044
 msgid "Temporary error, please try again"
 msgstr ""
 
@@ -408,7 +429,7 @@ msgstr ""
 msgid "Couldn't process request. Try again."
 msgstr ""
 
-#: workers/api.js:2887
-#: workers/api.js:2988
+#: workers/api.js:2901
+#: workers/api.js:3002
 msgid "Requested page not found"
 msgstr ""

--- a/views/account-identity-error.hbs
+++ b/views/account-identity-error.hbs
@@ -1,0 +1,32 @@
+{{!-- Shown when a setup link is restricted to a specific address (expectedEmail) and the account that
+was actually used is a different one; offers a link to restart the setup. Sibling of
+oauth-scope-error.hbs - the user made a correctable choice, so the flow stops here with a way back
+rather than bouncing them to the calling application. --}}
+
+<div class="ee-center">
+    <h1>{{_ "Wrong Email Account" templateLocale}}</h1>
+</div>
+
+<div class="ee-alert ee-alert-error">
+    <span class="ee-icon ee-icon-alert-triangle ee-icon-lg"></span>
+    <span>{{_ "This setup link can only be used with one specific email account, and a different one was used." templateLocale}}</span>
+</div>
+
+<dl class="ee-dl">
+    <dt>{{_ "Expected" templateLocale}}</dt>
+    <dd>{{expectedEmail}}</dd>
+    {{#if actualEmail}}
+    <dt>{{_ "Used" templateLocale}}</dt>
+    <dd>{{actualEmail}}</dd>
+    {{/if}}
+</dl>
+
+<p class="ee-muted">
+    {{_ "Try again and use the expected account. If you believe this is a mistake, contact the service that sent you this link." templateLocale}}
+</p>
+
+<div class="ee-form-actions">
+    <a href="{{retryUrl}}" class="ee-btn ee-btn-primary ee-btn-block">
+        <span class="ee-icon ee-icon-refresh"></span>{{_ "Try Again" templateLocale}}
+    </a>
+</div>

--- a/views/oauth-scope-error.hbs
+++ b/views/oauth-scope-error.hbs
@@ -24,7 +24,7 @@ permissions; offers a link to restart the consent flow. --}}
 </p>
 
 <div class="ee-form-actions">
-    <a href="{{reAuthUrl}}" class="ee-btn ee-btn-primary ee-btn-block">
+    <a href="{{retryUrl}}" class="ee-btn ee-btn-primary ee-btn-block">
         <span class="ee-icon ee-icon-refresh"></span>{{_ "Try Again" templateLocale}}
     </a>
 </div>

--- a/workers/api.js
+++ b/workers/api.js
@@ -8,7 +8,7 @@ const logger = require('../lib/logger');
 const Path = require('path');
 const Gettext = require('@postalsys/gettext');
 const { loadTranslations, gt, joiLocales, locales } = require('../lib/translations');
-const { accountStateLabel, formatServerState } = require('../lib/ui-routes/route-helpers');
+const { accountStateLabel, formatServerState, identityErrorView } = require('../lib/ui-routes/route-helpers');
 const util = require('util');
 const { webhooks: Webhooks } = require('../lib/webhooks');
 const featureFlags = require('../lib/feature-flags');
@@ -65,13 +65,8 @@ const { registeredPublishers, openChangeStream } = require('../lib/response-stre
 const { oauth2Apps } = require('../lib/oauth2-apps');
 const { decodeJwtPayload } = require('../lib/oauth/decode-jwt-payload');
 const { resolveOutlookUserInfo } = require('../lib/oauth/outlook-identity');
-const {
-    matchesExpectedIdentity,
-    pendingSetupExpectation,
-    resolveExpectedIdentity,
-    buildIdentityMismatchUrl,
-    IDENTITY_MISMATCH_MESSAGE
-} = require('../lib/account/expected-identity');
+const { buildRetrySetup } = require('../lib/oauth/retry-setup');
+const { matchesExpectedIdentity, pendingSetupExpectation, resolveExpectedIdentity } = require('../lib/account/expected-identity');
 
 const handlebars = require('handlebars');
 const AuthBearer = require('hapi-auth-bearer-token');
@@ -2065,6 +2060,18 @@ const init = async () => {
 
             const provider = accountData.oauth2.provider;
 
+            // What the caller originally asked for, captured before the provider branches below rewrite
+            // accountData from whoever signed in. A retry has to start from this rather than from the
+            // rejected attempt: `email` may name a shared mailbox to bind (and is otherwise overwritten
+            // with the authenticated address), `name` gets filled in from the rejected user's profile when
+            // the caller supplied none, and `oauth2.auth.delegatedUser` names the mailbox rather than a
+            // credential, so it must survive while the tokens do not.
+            const requestedSetup = {
+                email: accountData.email,
+                name: accountData.name,
+                delegatedUser: accountData.oauth2.auth && accountData.oauth2.auth.delegatedUser
+            };
+
             const oauth2App = await oauth2Apps.get(provider);
             if (!oauth2App) {
                 let error = Boom.boomify(new Error('Missing or disabled OAuth2 app'), { statusCode: 404 });
@@ -2085,6 +2092,21 @@ const init = async () => {
                         layout: 'public'
                     }
                 );
+
+            // Hands the user back to the provider after a failure they can correct themselves, as a fresh
+            // single-use setup. The token-bearing oauth2 object is dropped so the retry starts clean, and
+            // _meta rides along so the redirect URL, the expected identity and the form nonce all survive
+            // it - that nonce is claimed only on success, so it is still unspent here.
+            const startOAuthRetry = async (loginHint, prompt) => {
+                const reAuthState = `account:add:${crypto.randomBytes(NONCE_BYTES).toString('base64url')}`;
+                const reAuthAccountData = buildRetrySetup(accountData, requestedSetup, provider, accountMeta);
+
+                await redis.set(`${REDIS_PREFIX}${reAuthState}`, JSON.stringify(reAuthAccountData), 'EX', Math.floor(MAX_FORM_TTL / 1000));
+
+                // The address to steer the user towards rides on the authorize URL only - persisting it
+                // would overwrite a shared mailbox with the principal that is signing in to reach it.
+                return oAuth2Client.generateAuthUrl({ state: reAuthState, email: loginHint, prompt });
+            };
 
             // Addresses the provider itself returned over a back channel, the only values allowed to
             // satisfy an expected identity (see lib/account/expected-identity.js). Every provider case
@@ -2126,19 +2148,7 @@ const init = async () => {
                             request.logger.error({ msg: 'Failed to revoke partial OAuth2 token', err });
                         });
 
-                        const reAuthNonce = crypto.randomBytes(NONCE_BYTES).toString('base64url');
-                        const reAuthState = `account:add:${reAuthNonce}`;
-                        const reAuthAccountData = Object.assign({}, accountData, {
-                            oauth2: { provider },
-                            _meta: accountMeta
-                        });
-
-                        await redis.set(`${REDIS_PREFIX}${reAuthState}`, JSON.stringify(reAuthAccountData), 'EX', Math.floor(MAX_FORM_TTL / 1000));
-
-                        const reAuthUrl = oAuth2Client.generateAuthUrl({
-                            state: reAuthState,
-                            email: accountData.email
-                        });
+                        const retryUrl = await startOAuthRetry(accountData.email);
 
                         const missingScopesList = missingScopes.map(formatScopeDescription);
 
@@ -2147,7 +2157,7 @@ const init = async () => {
                             {
                                 pageTitleFull: request.app.gt.gettext('Email Account Setup'),
                                 templateLocale: request.app.locale,
-                                reAuthUrl,
+                                retryUrl,
                                 missingScopesList
                             },
                             {
@@ -2442,13 +2452,22 @@ const init = async () => {
                     }
                 }
 
-                if (redirectUrl) {
-                    return renderRedirect(buildIdentityMismatchUrl(redirectUrl, await settings.get('serviceUrl'), accountData.account));
-                }
+                // Stop here with a way back rather than redirecting to the calling application: signing in
+                // as the wrong account is a correctable mistake, and the hosted flow only ever redirects on
+                // success. Hint the address they were supposed to use, and force the account picker:
+                // they are already signed in to the one that just failed, so without select_account Google
+                // would hand back the same account and the retry would loop. Microsoft always shows the
+                // picker and Mail.ru ignores the hint, so this only changes Google's behavior.
+                const retryUrl = await startOAuthRetry(expectedEmail, 'select_account consent');
 
-                let error = Boom.boomify(new Error(IDENTITY_MISMATCH_MESSAGE), { statusCode: 403 });
-                error.output.payload.code = 'AccountIdentityMismatch';
-                throw error;
+                return identityErrorView(request, h, {
+                    expectedEmail,
+                    // The primary address the provider reported. Microsoft can return both a mailbox
+                    // address and a user principal name, and either would have satisfied the pin, so
+                    // naming the first is enough to show which account actually signed in.
+                    actualEmail: providerIdentities[0],
+                    retryUrl
+                });
             }
 
             if (expectedEmail) {


### PR DESCRIPTION
Follow-up to #627.

A hosted authentication setup rejected by `expectedEmail` redirected to the integrator's callback URL with error arguments. That made it the only failure in the flow that redirects. Every other one, including a consent screen with permissions unchecked, keeps the user on EmailEngine and shows them what went wrong (`views/oauth-scope-error.hbs`). Applications only ever hear from the hosted form when a setup succeeded, and forwarding this one error quietly broke that.

Signing in as the wrong account is a mistake the user can correct on the spot, so it now behaves like the missing-scopes case.

## What the user sees

A page naming the address the link expects and the one that was actually used, with a button to start over:

- **OAuth2** goes back to the provider with the account picker forced. The user is still signed in to the account that just failed, so without `select_account` Google hands back the same one and the retry loops. Microsoft always shows the picker; Mail.ru ignores the hint.
- **IMAP** returns to the credentials form, carrying `type=imap` so the user is not re-asked which provider they wanted. That form prefills the pinned address read-only.

Naming both addresses is what makes a near miss diagnosable. Matching is exact, so a Gmail address that gains or loses a dot, a `googlemail.com` alias, a `+tag`, or a Microsoft account pinned to its mailbox address rather than its user principal name all look like an unrelated mailbox otherwise.

The signed link is not consumed by a rejection (the nonce is claimed only on success), so the retry works. The grant obtained before the check is still revoked.

## A bug this surfaced

Retrying is now shared with the missing-scopes branch, and building the record handed to the next attempt needed more care than the original. By the time either failure is detected, the provider branches have already rewritten the pending setup from whoever signed in.

Carrying that forward wholesale drops `oauth2.auth.delegatedUser` and overwrites the shared mailbox address it pairs with. A retried Microsoft 365 delegated setup would then bind the **principal's own mailbox** instead of the shared one, pass the identity check, and report success. A display name taken from the rejected profile would likewise stick to the account and become its outgoing From name.

`lib/oauth/retry-setup.js` restores what the caller originally asked for and keeps the tokens out. It is a pure module so the property is actually testable, which the inline version was not.

## Contract change

`error=account_identity_mismatch` on the redirect is gone; nothing in the tree references it. It was introduced in #627 and never released, so no integrator can be relying on it.

## Testing

- Unit tier 1913/1913, including a new suite pinning what a retry inherits (tokens dropped, delegation kept, caller fields restored, `_meta` intact).
- Hosted-form integration 23/23. The rejection case now asserts the page names both addresses, offers the retry link, and does **not** redirect to the calling application.
- Followed the retry link end to end against a live instance: 403 error page, then 200 on the IMAP form with the pinned address prefilled and read-only.
- `/simplify` and `/security-review` both run; findings applied.
- Lint, formatter, gettext catalog and OpenAPI golden all updated.

Docs updated in the sibling repo.
