### PR TITLE
docs(translations): document the command-line catalog workflow

### DIFF
--- a/translations/README.md
+++ b/translations/README.md
@@ -2,6 +2,13 @@
 
 Translations only cover the public UI.
 
+`messages.pot` is the template listing every translatable string found in the source. Each `locale.po`
+holds one language's translations of those strings, and the `locale.mo` beside it is the compiled form
+that EmailEngine actually loads at runtime, so a `.po` change only takes effect once the `.mo` is
+regenerated and committed alongside it.
+
+A locale is served only if it is also listed in [locales.json](locales.json).
+
 ## Adding a new translation
 
 1. Create a new translation file using [POEdit](https://poedit.net/download)
@@ -10,6 +17,63 @@ Translations only cover the public UI.
 4. Add your translations
 5. Save file as `locale-name.po` (POEdit should autogenerate `locale-name.mo` as well)
 6. Make a pull request or send the po-file to andris@postalsys.com
+
+## Updating translations from the command line
+
+The same job with GNU gettext (`brew install gettext`, or the `gettext` package on Linux). Run these
+from the repository root.
+
+Refresh the template first, whenever source strings have been added or changed:
+
+```bash
+npm run gettext
+```
+
+That rewrites `messages.pot` from the views and JS. It also reorders entries as it goes, so expect a
+diff even when no string actually changed - compare the `msgid` lines rather than the line count.
+
+Then merge the template into each catalog and see what is missing:
+
+```bash
+cd translations
+for loc in en de et fr ja nl pl; do
+    msgmerge --update --backup=none --no-fuzzy-matching --quiet $loc.po messages.pot
+done
+
+msgattrib --untranslated de.po
+```
+
+`msgmerge` reorders entries to match the template, which makes the diff large while leaving existing
+translations untouched. `--no-fuzzy-matching` is deliberate: it keeps gettext from guessing a
+translation for a new string from a similar old one and marking it fuzzy, which is easy to miss in
+review.
+
+Fill in the empty `msgstr` values, then compile and confirm the counts:
+
+```bash
+for loc in en de et fr ja nl pl; do
+    msgfmt --check --statistics -o $loc.mo $loc.po
+done
+```
+
+Commit both the `.po` and the `.mo`.
+
+Notes:
+
+- `en.po` is left untranslated on purpose. English is the source language, so an empty `msgstr` falls
+  back to the `msgid`, and `msgfmt` reporting it as almost entirely untranslated is expected.
+- Match the register each catalog already uses rather than one house style. Today de, et and fr address
+  the user formally, ja is polite, and nl and pl are informal.
+- Reuse the wording a locale already chose for recurring terms. Checking how it translated
+  "Email Account Setup", for instance, settles how to render "setup" elsewhere.
+- The strings are extracted without message context, so a bare word like "Expected" cannot be
+  disambiguated by a translator. Prefer a short phrase when writing a new one.
+
+To check a page end to end, request it with the locale you want:
+
+```bash
+curl -H 'accept-language: de' 'http://127.0.0.1:3000/accounts/new?data=...&sig=...'
+```
 
 ## Validation error messages
 

--- a/translations/de.po
+++ b/translations/de.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"POT-Creation-Date: 2026-08-04 05:20+0000\n"
+"POT-Creation-Date: 2026-08-04 05:25+0000\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -37,6 +37,36 @@ msgstr[1] "%d Tage"
 #: views/redirect.hbs:1
 msgid "Click <a href=\"%s\">here</a> to continue&mldr;"
 msgstr "Klicken Sie <a href=\"%s\">hier</a>, um fortzufahren&mldr;"
+
+#: views/oauth-scope-error.hbs:5
+msgid "Insufficient Permissions"
+msgstr "Ungenügende Berechtigungen"
+
+#: views/oauth-scope-error.hbs:10
+msgid ""
+"All requested permissions are required for this service to function "
+"properly. Some required permissions were not granted during sign-in."
+msgstr ""
+"Alle angeforderten Berechtigungen sind erforderlich, damit dieser Dienst "
+"ordnungsgemäß funktioniert. Einige der erforderlichen Berechtigungen wurden "
+"bei der Anmeldung nicht erteilt."
+
+#: views/oauth-scope-error.hbs:14
+msgid "The following permissions were not granted:"
+msgstr "Die folgenden Berechtigungen wurden nicht erteilt:"
+
+#: views/oauth-scope-error.hbs:23
+msgid ""
+"Please try again and make sure all permission checkboxes are selected on the "
+"Google consent screen."
+msgstr ""
+"Bitte versuchen Sie es erneut und stellen Sie sicher, dass auf dem Google-"
+"Einwilligungsbildschirm alle Kontrollkästchen für die Berechtigungen "
+"aktiviert sind."
+
+#: views/oauth-scope-error.hbs:28 views/account-identity-error.hbs:32
+msgid "Try Again"
+msgstr "Noch einmal versuchen"
 
 #: views/unsubscribe.hbs:7 views/unsubscribe.hbs:60 views/unsubscribe.hbs:75
 msgid "Unsubscribe"
@@ -82,36 +112,6 @@ msgstr ""
 #: views/unsubscribe.hbs:70 views/accounts/register/imap.hbs:25
 msgid "Email address"
 msgstr "E-Mail-Adresse"
-
-#: views/oauth-scope-error.hbs:5
-msgid "Insufficient Permissions"
-msgstr "Ungenügende Berechtigungen"
-
-#: views/oauth-scope-error.hbs:10
-msgid ""
-"All requested permissions are required for this service to function "
-"properly. Some required permissions were not granted during sign-in."
-msgstr ""
-"Alle angeforderten Berechtigungen sind erforderlich, damit dieser Dienst "
-"ordnungsgemäß funktioniert. Einige der erforderlichen Berechtigungen wurden "
-"bei der Anmeldung nicht erteilt."
-
-#: views/oauth-scope-error.hbs:14
-msgid "The following permissions were not granted:"
-msgstr "Die folgenden Berechtigungen wurden nicht erteilt:"
-
-#: views/oauth-scope-error.hbs:23
-msgid ""
-"Please try again and make sure all permission checkboxes are selected on the "
-"Google consent screen."
-msgstr ""
-"Bitte versuchen Sie es erneut und stellen Sie sicher, dass auf dem Google-"
-"Einwilligungsbildschirm alle Kontrollkästchen für die Berechtigungen "
-"aktiviert sind."
-
-#: views/oauth-scope-error.hbs:28 views/account-identity-error.hbs:32
-msgid "Try Again"
-msgstr "Noch einmal versuchen"
 
 #: views/accounts/register/imap.hbs:13
 msgid "Your name"

--- a/translations/en.po
+++ b/translations/en.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"POT-Creation-Date: 2026-08-04 05:20+0000\n"
+"POT-Creation-Date: 2026-08-04 05:25+0000\n"
 "PO-Revision-Date: 2026-03-31 16:57+0300\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -37,6 +37,30 @@ msgstr[1] ""
 
 #: views/redirect.hbs:1
 msgid "Click <a href=\"%s\">here</a> to continue&mldr;"
+msgstr ""
+
+#: views/oauth-scope-error.hbs:5
+msgid "Insufficient Permissions"
+msgstr ""
+
+#: views/oauth-scope-error.hbs:10
+msgid ""
+"All requested permissions are required for this service to function "
+"properly. Some required permissions were not granted during sign-in."
+msgstr ""
+
+#: views/oauth-scope-error.hbs:14
+msgid "The following permissions were not granted:"
+msgstr ""
+
+#: views/oauth-scope-error.hbs:23
+msgid ""
+"Please try again and make sure all permission checkboxes are selected on the "
+"Google consent screen."
+msgstr ""
+
+#: views/oauth-scope-error.hbs:28 views/account-identity-error.hbs:32
+msgid "Try Again"
 msgstr ""
 
 #: views/unsubscribe.hbs:7 views/unsubscribe.hbs:60 views/unsubscribe.hbs:75
@@ -77,30 +101,6 @@ msgstr ""
 
 #: views/unsubscribe.hbs:70 views/accounts/register/imap.hbs:25
 msgid "Email address"
-msgstr ""
-
-#: views/oauth-scope-error.hbs:5
-msgid "Insufficient Permissions"
-msgstr ""
-
-#: views/oauth-scope-error.hbs:10
-msgid ""
-"All requested permissions are required for this service to function "
-"properly. Some required permissions were not granted during sign-in."
-msgstr ""
-
-#: views/oauth-scope-error.hbs:14
-msgid "The following permissions were not granted:"
-msgstr ""
-
-#: views/oauth-scope-error.hbs:23
-msgid ""
-"Please try again and make sure all permission checkboxes are selected on the "
-"Google consent screen."
-msgstr ""
-
-#: views/oauth-scope-error.hbs:28 views/account-identity-error.hbs:32
-msgid "Try Again"
 msgstr ""
 
 #: views/accounts/register/imap.hbs:13

--- a/translations/et.po
+++ b/translations/et.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"POT-Creation-Date: 2026-08-04 05:20+0000\n"
+"POT-Creation-Date: 2026-08-04 05:25+0000\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -37,6 +37,34 @@ msgstr[1] "%d päeva"
 #: views/redirect.hbs:1
 msgid "Click <a href=\"%s\">here</a> to continue&mldr;"
 msgstr "Kliki <a href=\"%s\">siin</a>, et jätkata&mldr;"
+
+#: views/oauth-scope-error.hbs:5
+msgid "Insufficient Permissions"
+msgstr "Puuduvad õigused"
+
+#: views/oauth-scope-error.hbs:10
+msgid ""
+"All requested permissions are required for this service to function "
+"properly. Some required permissions were not granted during sign-in."
+msgstr ""
+"Teenuse korrektseks toimimiseks on vajalikud kõik taotletud õigused. "
+"Mõningaid vajalikke õigusi ei antud sisselogimisel."
+
+#: views/oauth-scope-error.hbs:14
+msgid "The following permissions were not granted:"
+msgstr "Järgmisi õigusi ei antud:"
+
+#: views/oauth-scope-error.hbs:23
+msgid ""
+"Please try again and make sure all permission checkboxes are selected on the "
+"Google consent screen."
+msgstr ""
+"Palun proovige uuesti ja veenduge, et Google’i nõusolekuaknas oleksid kõik "
+"lubade valikukastid märgitud."
+
+#: views/oauth-scope-error.hbs:28 views/account-identity-error.hbs:32
+msgid "Try Again"
+msgstr "Proovige uuesti"
 
 #: views/unsubscribe.hbs:7 views/unsubscribe.hbs:60 views/unsubscribe.hbs:75
 msgid "Unsubscribe"
@@ -80,34 +108,6 @@ msgstr "Teie e-posti aadress <em>%s</em> lisati uuesti tellijate nimekirja."
 #: views/unsubscribe.hbs:70 views/accounts/register/imap.hbs:25
 msgid "Email address"
 msgstr "E-posti aadress"
-
-#: views/oauth-scope-error.hbs:5
-msgid "Insufficient Permissions"
-msgstr "Puuduvad õigused"
-
-#: views/oauth-scope-error.hbs:10
-msgid ""
-"All requested permissions are required for this service to function "
-"properly. Some required permissions were not granted during sign-in."
-msgstr ""
-"Teenuse korrektseks toimimiseks on vajalikud kõik taotletud õigused. "
-"Mõningaid vajalikke õigusi ei antud sisselogimisel."
-
-#: views/oauth-scope-error.hbs:14
-msgid "The following permissions were not granted:"
-msgstr "Järgmisi õigusi ei antud:"
-
-#: views/oauth-scope-error.hbs:23
-msgid ""
-"Please try again and make sure all permission checkboxes are selected on the "
-"Google consent screen."
-msgstr ""
-"Palun proovige uuesti ja veenduge, et Google’i nõusolekuaknas oleksid kõik "
-"lubade valikukastid märgitud."
-
-#: views/oauth-scope-error.hbs:28 views/account-identity-error.hbs:32
-msgid "Try Again"
-msgstr "Proovige uuesti"
 
 #: views/accounts/register/imap.hbs:13
 msgid "Your name"

--- a/translations/fr.po
+++ b/translations/fr.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"POT-Creation-Date: 2026-08-04 05:20+0000\n"
+"POT-Creation-Date: 2026-08-04 05:25+0000\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -37,6 +37,35 @@ msgstr[1] "%d jours"
 #: views/redirect.hbs:1
 msgid "Click <a href=\"%s\">here</a> to continue&mldr;"
 msgstr "Cliquez sur <a href=\"%s\">ici</a> pour continuer&mldr;"
+
+#: views/oauth-scope-error.hbs:5
+msgid "Insufficient Permissions"
+msgstr "Autorisations insuffisantes"
+
+#: views/oauth-scope-error.hbs:10
+msgid ""
+"All requested permissions are required for this service to function "
+"properly. Some required permissions were not granted during sign-in."
+msgstr ""
+"Toutes les autorisations demandées sont nécessaires au bon fonctionnement de "
+"ce service. Certaines autorisations requises n'ont pas été accordées lors de "
+"la connexion."
+
+#: views/oauth-scope-error.hbs:14
+msgid "The following permissions were not granted:"
+msgstr "Les autorisations suivantes n'ont pas été accordées :"
+
+#: views/oauth-scope-error.hbs:23
+msgid ""
+"Please try again and make sure all permission checkboxes are selected on the "
+"Google consent screen."
+msgstr ""
+"Veuillez réessayer et vous assurer que toutes les cases d'autorisation sont "
+"cochées sur l'écran de consentement de Google."
+
+#: views/oauth-scope-error.hbs:28 views/account-identity-error.hbs:32
+msgid "Try Again"
+msgstr "Essayer de nouveau"
 
 #: views/unsubscribe.hbs:7 views/unsubscribe.hbs:60 views/unsubscribe.hbs:75
 msgid "Unsubscribe"
@@ -77,35 +106,6 @@ msgstr "Votre adresse e-mail <em>%s</em> a été réinscrite."
 #: views/unsubscribe.hbs:70 views/accounts/register/imap.hbs:25
 msgid "Email address"
 msgstr "Adresse e-mail"
-
-#: views/oauth-scope-error.hbs:5
-msgid "Insufficient Permissions"
-msgstr "Autorisations insuffisantes"
-
-#: views/oauth-scope-error.hbs:10
-msgid ""
-"All requested permissions are required for this service to function "
-"properly. Some required permissions were not granted during sign-in."
-msgstr ""
-"Toutes les autorisations demandées sont nécessaires au bon fonctionnement de "
-"ce service. Certaines autorisations requises n'ont pas été accordées lors de "
-"la connexion."
-
-#: views/oauth-scope-error.hbs:14
-msgid "The following permissions were not granted:"
-msgstr "Les autorisations suivantes n'ont pas été accordées :"
-
-#: views/oauth-scope-error.hbs:23
-msgid ""
-"Please try again and make sure all permission checkboxes are selected on the "
-"Google consent screen."
-msgstr ""
-"Veuillez réessayer et vous assurer que toutes les cases d'autorisation sont "
-"cochées sur l'écran de consentement de Google."
-
-#: views/oauth-scope-error.hbs:28 views/account-identity-error.hbs:32
-msgid "Try Again"
-msgstr "Essayer de nouveau"
 
 #: views/accounts/register/imap.hbs:13
 msgid "Your name"

--- a/translations/ja.po
+++ b/translations/ja.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"POT-Creation-Date: 2026-08-04 05:20+0000\n"
+"POT-Creation-Date: 2026-08-04 05:25+0000\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -36,6 +36,34 @@ msgstr[0] "%d日"
 #: views/redirect.hbs:1
 msgid "Click <a href=\"%s\">here</a> to continue&mldr;"
 msgstr "続き<a href=\"%s\">はこちら</a>をクリック&mldr;"
+
+#: views/oauth-scope-error.hbs:5
+msgid "Insufficient Permissions"
+msgstr "権限不足"
+
+#: views/oauth-scope-error.hbs:10
+msgid ""
+"All requested permissions are required for this service to function "
+"properly. Some required permissions were not granted during sign-in."
+msgstr ""
+"このサービスが正常に動作するには、要求されたすべての権限が必要です。サインイ"
+"ン時に、必要な権限の一部が付与されませんでした。"
+
+#: views/oauth-scope-error.hbs:14
+msgid "The following permissions were not granted:"
+msgstr "以下の権限は付与されませんでした："
+
+#: views/oauth-scope-error.hbs:23
+msgid ""
+"Please try again and make sure all permission checkboxes are selected on the "
+"Google consent screen."
+msgstr ""
+"もう一度お試しいただき、Googleの同意画面で全ての権限のチェックボックスが選択"
+"されていることをご確認ください。"
+
+#: views/oauth-scope-error.hbs:28 views/account-identity-error.hbs:32
+msgid "Try Again"
+msgstr "もう一度試してください"
 
 #: views/unsubscribe.hbs:7 views/unsubscribe.hbs:60 views/unsubscribe.hbs:75
 msgid "Unsubscribe"
@@ -76,34 +104,6 @@ msgstr "メールアドレス<em>%s</em>が再購読されました。"
 #: views/unsubscribe.hbs:70 views/accounts/register/imap.hbs:25
 msgid "Email address"
 msgstr "メールアドレス"
-
-#: views/oauth-scope-error.hbs:5
-msgid "Insufficient Permissions"
-msgstr "権限不足"
-
-#: views/oauth-scope-error.hbs:10
-msgid ""
-"All requested permissions are required for this service to function "
-"properly. Some required permissions were not granted during sign-in."
-msgstr ""
-"このサービスが正常に動作するには、要求されたすべての権限が必要です。サインイ"
-"ン時に、必要な権限の一部が付与されませんでした。"
-
-#: views/oauth-scope-error.hbs:14
-msgid "The following permissions were not granted:"
-msgstr "以下の権限は付与されませんでした："
-
-#: views/oauth-scope-error.hbs:23
-msgid ""
-"Please try again and make sure all permission checkboxes are selected on the "
-"Google consent screen."
-msgstr ""
-"もう一度お試しいただき、Googleの同意画面で全ての権限のチェックボックスが選択"
-"されていることをご確認ください。"
-
-#: views/oauth-scope-error.hbs:28 views/account-identity-error.hbs:32
-msgid "Try Again"
-msgstr "もう一度試してください"
 
 #: views/accounts/register/imap.hbs:13
 msgid "Your name"

--- a/translations/nl.po
+++ b/translations/nl.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"POT-Creation-Date: 2026-08-04 05:20+0000\n"
+"POT-Creation-Date: 2026-08-04 05:25+0000\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -37,6 +37,34 @@ msgstr[1] "%d dagen"
 #: views/redirect.hbs:1
 msgid "Click <a href=\"%s\">here</a> to continue&mldr;"
 msgstr "Klik <a href=\"%s\">hier</a> om door te gaan&mldr;"
+
+#: views/oauth-scope-error.hbs:5
+msgid "Insufficient Permissions"
+msgstr "Onvoldoende rechten"
+
+#: views/oauth-scope-error.hbs:10
+msgid ""
+"All requested permissions are required for this service to function "
+"properly. Some required permissions were not granted during sign-in."
+msgstr ""
+"Alle gevraagde machtigingen zijn vereist om deze dienst correct te laten "
+"werken. Bij het inloggen zijn sommige vereiste machtigingen niet verleend."
+
+#: views/oauth-scope-error.hbs:14
+msgid "The following permissions were not granted:"
+msgstr "De volgende machtigingen zijn niet verleend:"
+
+#: views/oauth-scope-error.hbs:23
+msgid ""
+"Please try again and make sure all permission checkboxes are selected on the "
+"Google consent screen."
+msgstr ""
+"Probeer het nog eens en zorg ervoor dat alle selectievakjes voor toestemming "
+"op het toestemmingsscherm van Google zijn aangevinkt."
+
+#: views/oauth-scope-error.hbs:28 views/account-identity-error.hbs:32
+msgid "Try Again"
+msgstr "Probeer opnieuw"
 
 #: views/unsubscribe.hbs:7 views/unsubscribe.hbs:60 views/unsubscribe.hbs:75
 msgid "Unsubscribe"
@@ -79,34 +107,6 @@ msgstr "Je e-mailadres <em>%s</em> is opnieuw geabonneerd."
 #: views/unsubscribe.hbs:70 views/accounts/register/imap.hbs:25
 msgid "Email address"
 msgstr "E-mailadres"
-
-#: views/oauth-scope-error.hbs:5
-msgid "Insufficient Permissions"
-msgstr "Onvoldoende rechten"
-
-#: views/oauth-scope-error.hbs:10
-msgid ""
-"All requested permissions are required for this service to function "
-"properly. Some required permissions were not granted during sign-in."
-msgstr ""
-"Alle gevraagde machtigingen zijn vereist om deze dienst correct te laten "
-"werken. Bij het inloggen zijn sommige vereiste machtigingen niet verleend."
-
-#: views/oauth-scope-error.hbs:14
-msgid "The following permissions were not granted:"
-msgstr "De volgende machtigingen zijn niet verleend:"
-
-#: views/oauth-scope-error.hbs:23
-msgid ""
-"Please try again and make sure all permission checkboxes are selected on the "
-"Google consent screen."
-msgstr ""
-"Probeer het nog eens en zorg ervoor dat alle selectievakjes voor toestemming "
-"op het toestemmingsscherm van Google zijn aangevinkt."
-
-#: views/oauth-scope-error.hbs:28 views/account-identity-error.hbs:32
-msgid "Try Again"
-msgstr "Probeer opnieuw"
 
 #: views/accounts/register/imap.hbs:13
 msgid "Your name"

--- a/translations/pl.po
+++ b/translations/pl.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"POT-Creation-Date: 2026-08-04 05:20+0000\n"
+"POT-Creation-Date: 2026-08-04 05:25+0000\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -39,6 +39,34 @@ msgstr[2] "%d dni"
 #: views/redirect.hbs:1
 msgid "Click <a href=\"%s\">here</a> to continue&mldr;"
 msgstr "Kliknij <a href=\"%s\">tutaj</a>, aby kontynuować&mldr;"
+
+#: views/oauth-scope-error.hbs:5
+msgid "Insufficient Permissions"
+msgstr "Niewystarczające uprawnienia"
+
+#: views/oauth-scope-error.hbs:10
+msgid ""
+"All requested permissions are required for this service to function "
+"properly. Some required permissions were not granted during sign-in."
+msgstr ""
+"Wszystkie wymagane uprawnienia są niezbędne do prawidłowego działania tej "
+"usługi. Niektóre z nich nie zostały przyznane podczas logowania."
+
+#: views/oauth-scope-error.hbs:14
+msgid "The following permissions were not granted:"
+msgstr "Nie przyznano następujących uprawnień:"
+
+#: views/oauth-scope-error.hbs:23
+msgid ""
+"Please try again and make sure all permission checkboxes are selected on the "
+"Google consent screen."
+msgstr ""
+"Spróbuj ponownie i upewnij się, że na ekranie zgody Google zaznaczone są "
+"wszystkie pola wyboru dotyczące uprawnień."
+
+#: views/oauth-scope-error.hbs:28 views/account-identity-error.hbs:32
+msgid "Try Again"
+msgstr "Spróbuj ponownie"
 
 #: views/unsubscribe.hbs:7 views/unsubscribe.hbs:60 views/unsubscribe.hbs:75
 msgid "Unsubscribe"
@@ -80,34 +108,6 @@ msgstr "Twój adres e-mail <em>%s</em> został ponownie zasubskrybowany."
 #: views/unsubscribe.hbs:70 views/accounts/register/imap.hbs:25
 msgid "Email address"
 msgstr "Adres e-mail"
-
-#: views/oauth-scope-error.hbs:5
-msgid "Insufficient Permissions"
-msgstr "Niewystarczające uprawnienia"
-
-#: views/oauth-scope-error.hbs:10
-msgid ""
-"All requested permissions are required for this service to function "
-"properly. Some required permissions were not granted during sign-in."
-msgstr ""
-"Wszystkie wymagane uprawnienia są niezbędne do prawidłowego działania tej "
-"usługi. Niektóre z nich nie zostały przyznane podczas logowania."
-
-#: views/oauth-scope-error.hbs:14
-msgid "The following permissions were not granted:"
-msgstr "Nie przyznano następujących uprawnień:"
-
-#: views/oauth-scope-error.hbs:23
-msgid ""
-"Please try again and make sure all permission checkboxes are selected on the "
-"Google consent screen."
-msgstr ""
-"Spróbuj ponownie i upewnij się, że na ekranie zgody Google zaznaczone są "
-"wszystkie pola wyboru dotyczące uprawnień."
-
-#: views/oauth-scope-error.hbs:28 views/account-identity-error.hbs:32
-msgid "Try Again"
-msgstr "Spróbuj ponownie"
 
 #: views/accounts/register/imap.hbs:13
 msgid "Your name"


### PR DESCRIPTION
Follow-up to #629.

`translations/README.md` only described the POEdit path. That suits an outside contributor sending in one language, but not a maintainer refreshing all of them, and it left three things unsaid:

- where `messages.pot` comes from (`npm run gettext` was not mentioned at all)
- that the `.mo` is what EmailEngine actually loads, so a `.po` edit does nothing until it is recompiled and committed
- that a locale has to be listed in `locales.json` before it is served, so a correctly translated new `.po` could still never render

Adds the GNU gettext equivalent of the whole loop, plus the parts that are easy to get wrong:

- `en.po` is untranslated on purpose (source language, empty msgstr falls back to the msgid), so `msgfmt` reporting it as almost entirely untranslated is expected rather than a bug to fix
- `--no-fuzzy-matching` is deliberate: it stops gettext guessing a translation for a new string from a similar old one and marking it fuzzy, which is easy to wave through in review
- `msgmerge` reorders entries to match the template, so diffs are large without content changing - compare `msgid` lines, not line counts
- each catalog has its own register to match rather than one house style
- strings carry no message context, so a bare word like "Expected" cannot be disambiguated by a translator

## Catalogs settled

Running the documented commands turned out to produce a diff, which would have made the README wrong on its first use. The catalogs had been committed with `.po` headers older than the template and with entries not yet in template order. This commit settles them.

Content is unchanged, verified rather than assumed:

- no translation added, lost or altered in any locale (0/0/0 across all seven)
- no `.mo` file is part of this commit, so nothing EmailEngine loads at runtime differs
- a second run of the documented commands is now a no-op, so the next person gets a clean diff

Gettext coverage test passing.
