### PR TITLE
test(e2e): share the token-reveal dismissal instead of re-deriving it

### DIFF
--- a/test/e2e/helpers/bootstrap.js
+++ b/test/e2e/helpers/bootstrap.js
@@ -86,4 +86,26 @@ async function createApiToken(page, description = 'e2e token') {
     return tokenInput.inputValue();
 }
 
-module.exports = { ADMIN_PASSWORD, PORT, BASE_URL, ensureAdminSession, ensureTrial, createApiToken, trackConsoleErrors };
+/**
+ * Dismisses the one-time token reveal modal createApiToken leaves open.
+ *
+ * Two waits, and both are load-bearing. The opening transition has to settle first, because a click
+ * landing mid-animation is swallowed and the modal never emits its close event - the Done button
+ * then appears to do nothing and whatever waits for the listing waits forever. And the close handler
+ * navigates by location.assign, so the caller has to wait that out rather than issue a navigation of
+ * its own into it, which aborts with ERR_ABORTED.
+ *
+ * The URL pattern is anchored on what follows the path on purpose: an unanchored /\/admin\/tokens/
+ * also matches the /admin/tokens/new the page is still on, so the wait returns against the CURRENT
+ * url and gives none of the protection above.
+ *
+ * Lives here rather than in a spec because it is the counterpart of createApiToken, and a spec that
+ * re-derived it got both waits wrong - one failing only on a slower machine, the other only in CI.
+ */
+async function dismissTokenReveal(page) {
+    await expect(page.locator('#showToken')).toHaveCSS('opacity', '1');
+    await page.locator('#showToken button', { hasText: 'Done' }).click();
+    await page.waitForURL(/\/admin\/tokens(\?|$)/);
+}
+
+module.exports = { ADMIN_PASSWORD, PORT, BASE_URL, ensureAdminSession, ensureTrial, createApiToken, dismissTokenReveal, trackConsoleErrors };

--- a/test/e2e/pages-admin.spec.js
+++ b/test/e2e/pages-admin.spec.js
@@ -19,7 +19,7 @@
 const os = require('os');
 const path = require('path');
 const { test, expect, request } = require('@playwright/test');
-const { ensureAdminSession, createApiToken, trackConsoleErrors, BASE_URL } = require('./helpers/bootstrap');
+const { ensureAdminSession, createApiToken, dismissTokenReveal, trackConsoleErrors, BASE_URL } = require('./helpers/bootstrap');
 
 // One real login per run: the admin session cookie is captured in beforeAll and
 // reused by every test via storageState. Logging in per test trips the login
@@ -133,16 +133,6 @@ async function deleteViaModal(page, listUrlRe, opts) {
     }
     await page.locator('#deleteModal button[type="submit"]').click();
     await page.waitForURL(listUrlRe);
-}
-
-// Dismisses the one-time token reveal modal createApiToken leaves open: settle
-// the opening transition (a click mid-animation is swallowed), then wait out the
-// location.assign the Done button triggers - navigating while it is in flight
-// aborts with ERR_ABORTED.
-async function dismissTokenReveal(page) {
-    await expect(page.locator('#showToken')).toHaveCSS('opacity', '1');
-    await page.locator('#showToken button', { hasText: 'Done' }).click();
-    await page.waitForURL(/\/admin\/tokens(\?|$)/);
 }
 
 // Asserts the TLS certificate label's FlyonUI tooltip: the cert status text

--- a/test/e2e/pages-tokens.spec.js
+++ b/test/e2e/pages-tokens.spec.js
@@ -18,7 +18,7 @@
 const os = require('os');
 const path = require('path');
 const { test, expect } = require('@playwright/test');
-const { ensureAdminSession, trackConsoleErrors, BASE_URL } = require('./helpers/bootstrap');
+const { ensureAdminSession, dismissTokenReveal, trackConsoleErrors, BASE_URL } = require('./helpers/bootstrap');
 
 const STATE_FILE = path.join(os.tmpdir(), 'ee-e2e-tokens-state.json');
 
@@ -145,10 +145,10 @@ test.describe('access token pages', () => {
         const overflow = await tokenValue.evaluate(el => el.scrollWidth - el.clientWidth);
         expect(overflow, 'the access token does not fit its field and is being cut off').toBeLessThanOrEqual(0);
 
-        await page.getByRole('button', { name: 'Done' }).click();
-
-        // Closing the reveal modal navigates back to the listing
-        await page.waitForURL(/\/admin\/tokens/);
+        // Closing the reveal modal navigates back to the listing. Through the shared helper, which
+        // settles the opening transition before clicking and waits the navigation out - this spec
+        // used to do it by hand and got both halves wrong.
+        await dismissTokenReveal(page);
 
         // Searched rather than scanned: tokens.list() sorts by the token hash, so a newly minted one
         // lands in an arbitrary position and falls off page one once the shared instance has enough


### PR DESCRIPTION
Fixes the e2e failure on master from #633. `pages-tokens.spec.js` closed the one-time token reveal modal by hand and got both of the waits that sequence needs wrong:

- **No settle before the click.** A click landing mid-animation is swallowed, so the modal never emits its close event and nothing navigates. Locally this hangs until the 5 minute test timeout.
- **Unanchored URL wait.** The pattern `/admin/tokens` also matches the `/admin/tokens/new` the page is still on, so `waitForURL` returned against the *current* url and the `goto` after it raced the modal's own `location.assign` - `net::ERR_ABORTED`. This is what failed in CI, where the animation had settled and the click landed.

`pages-admin.spec.js` already had both right in a local `dismissTokenReveal`, whose comment names both hazards. It moves to `test/e2e/helpers/bootstrap.js` beside `createApiToken`, and both specs call it.

The e2e tier only runs on push to master and `workflow_dispatch`, which is why this surfaced after the merge rather than on the pull request. Verified locally: **98 passed**. The e2e workflow is also dispatched against this branch, since the PR checks do not include it.
