### PR TITLE
fix(deps): override deepmerge-ts to clear GHSA-ggr8-5vv4-36mx

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3624,9 +3624,9 @@
             "license": "MIT"
         },
         "node_modules/deepmerge-ts": {
-            "version": "7.1.6",
-            "resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-7.1.6.tgz",
-            "integrity": "sha512-gQhL1ksGBLQbHeAo47YU6cs2ahd3Pv+8PFYoWogNZbQnNwQyOh9Ad5kbeHFiWwbKdeWQJ5Z7Y7mwb9ew2hXBLw==",
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-8.0.1.tgz",
+            "integrity": "sha512-szCXE7YLCvLKR9bFPJcvsezOShdalctSvrgN/LM/QGUEPZQajwjmsMObZ6/DuANT5lxzM/wtO8Feubwdkz8myA==",
             "funding": [
                 {
                     "type": "ko-fi",

--- a/package.json
+++ b/package.json
@@ -138,7 +138,8 @@
         "xgettext-template": "5.0.0"
     },
     "overrides": {
-        "@asamuzakjp/css-color": "4.1.1"
+        "@asamuzakjp/css-color": "4.1.1",
+        "deepmerge-ts": "^8.0.1"
     },
     "engines": {
         "node": ">=20.x"

--- a/static/licenses.html
+++ b/static/licenses.html
@@ -1634,7 +1634,7 @@ SOFTWARE.</pre></details>
 <li class="package">
 <div class="head">
 <span class="name">@ioredis/commands</span>
-<span class="version">1.10.0</span>
+<span class="version">2.0.0</span>
 <span class="badge">MIT</span>
 <span class="badge badge-runtime">runtime</span>
 <span class="links"><a href="https://npmjs.com/package/@ioredis/commands" rel="noopener noreferrer">npm</a> <a href="https://github.com/ioredis/commands" rel="noopener noreferrer">website</a></span>
@@ -1661,6 +1661,16 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.</pre></details>
+</li>
+<li class="package">
+<div class="head">
+<span class="name">@ioredis/commands</span>
+<span class="version">1.10.0</span>
+<span class="badge">MIT</span>
+<span class="badge badge-runtime">runtime</span>
+<span class="links"><a href="https://npmjs.com/package/@ioredis/commands" rel="noopener noreferrer">npm</a> <a href="https://github.com/ioredis/commands" rel="noopener noreferrer">website</a></span>
+</div>
+<p class="no-text">Same license text as <a href="#lic-38">@ioredis/commands</a>.</p>
 </li>
 <li class="package">
 <div class="head">
@@ -4408,7 +4418,7 @@ THE SOFTWARE.</pre></details>
 <li class="package">
 <div class="head">
 <span class="name">bullmq</span>
-<span class="version">5.81.3</span>
+<span class="version">6.1.2</span>
 <span class="badge">MIT</span>
 <span class="badge badge-runtime">runtime</span>
 <span class="links"><a href="https://npmjs.com/package/bullmq" rel="noopener noreferrer">npm</a> <a href="https://bullmq.io/" rel="noopener noreferrer">website</a></span>
@@ -4700,14 +4710,14 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</pre></details>
 <li class="package">
 <div class="head">
 <span class="name">cron-parser</span>
-<span class="version">4.9.0</span>
+<span class="version">5.10.0</span>
 <span class="badge">MIT</span>
 <span class="badge badge-runtime">runtime</span>
 <span class="links"><a href="https://npmjs.com/package/cron-parser" rel="noopener noreferrer">npm</a> <a href="https://github.com/harrisiirak/cron-parser" rel="noopener noreferrer">website</a></span>
 </div>
 <details id="lic-98"><summary>Show license text</summary><pre>The MIT License (MIT)
 
-Copyright (c) 2014-2016 Harri Siirak
+Copyright (c) 2014-2023 Harri Siirak
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the &#x22;Software&#x22;), to deal
@@ -4941,7 +4951,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</pre>
 <li class="package">
 <div class="head">
 <span class="name">deepmerge-ts</span>
-<span class="version">7.1.6</span>
+<span class="version">8.0.1</span>
 <span class="badge">BSD-3-Clause</span>
 <span class="badge badge-runtime">runtime</span>
 <span class="links"><a href="https://npmjs.com/package/deepmerge-ts" rel="noopener noreferrer">npm</a> <a href="https://github.com/RebeccaStevens/deepmerge-ts#readme" rel="noopener noreferrer">website</a></span>
@@ -7132,10 +7142,10 @@ SOFTWARE.</pre></details>
 <li class="package">
 <div class="head">
 <span class="name">ioredis</span>
-<span class="version">5.11.1</span>
+<span class="version">6.0.0</span>
 <span class="badge">MIT</span>
 <span class="badge badge-runtime">runtime</span>
-<span class="links"><a href="https://npmjs.com/package/ioredis" rel="noopener noreferrer">npm</a> <a href="https://github.com/luin/ioredis" rel="noopener noreferrer">website</a></span>
+<span class="links"><a href="https://npmjs.com/package/ioredis" rel="noopener noreferrer">npm</a> <a href="https://github.com/redis/ioredis" rel="noopener noreferrer">website</a></span>
 </div>
 <details id="lic-139"><summary>Show license text</summary><pre>The MIT License (MIT)
 
@@ -7158,6 +7168,16 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.</pre></details>
+</li>
+<li class="package">
+<div class="head">
+<span class="name">ioredis</span>
+<span class="version">5.11.1</span>
+<span class="badge">MIT</span>
+<span class="badge badge-runtime">runtime</span>
+<span class="links"><a href="https://npmjs.com/package/ioredis" rel="noopener noreferrer">npm</a> <a href="https://github.com/luin/ioredis" rel="noopener noreferrer">website</a></span>
+</div>
+<p class="no-text">Same license text as <a href="#lic-139">ioredis</a>.</p>
 </li>
 <li class="package">
 <div class="head">


### PR DESCRIPTION
Closes Dependabot alert #87.

`deepmerge-ts` below 8.0.0 has no cycle detection in its record merge, so two objects that both self-reference through the same key path recurse until Node throws `RangeError` (CVE-2026-40345, availability only).

### Why an override rather than a bump

There is nothing to bump to. It reaches us only through `html-to-text`, which is already on its latest release (10.0.0) and still asks for `deepmerge-ts@^7.1.5`.

### Reachability here

Not reachable from mail, so this is hygiene rather than a live hole. `html-to-text` uses `deepmerge-ts` in exactly two places, both merging its **options** - the default option set against the caller's, and one selector map against another. The HTML being converted never passes through it, and both of our call sites (`lib/generate-text-preview.js`, the IMAP proxy indexer) hand it static option objects with no self-references.

### Why forcing 8.0.1 is safe

- **Same packaging.** 8.0.1 ships dual CJS/ESM off one exports map with `engines: node>=16`, identical to 7.1.6 - so the pkg binary build is unaffected. An ESM-only major here would have broken it with nothing in the test suite noticing.
- **Breaking changes do not apply.** Deep Map merging (html-to-text merges plain objects, never Maps) and TypeScript type renames (runtime unaffected; html-to-text ships JavaScript).
- **Verified, not assumed.** html-to-text output is byte-identical across the bare call, a call with custom selectors, a compiled converter, and `generateTextPreview`. The advisory PoC `RangeError`s on 7.1.6 and merges cleanly on 8.0.1.

### Artifacts

`static/licenses.html` is regenerated, which also picks up entries that went stale earlier: bullmq 5.81.3 to 6.1.2, ioredis 5.11.1 to 6.0.0, cron-parser 4.9.0 to 5.10.0 were bumped without the listing being rebuilt. `sbom.json` and `data/google-crawlers.json` are deliberately untouched - both are refetched artifacts that always diff and neither relates to this.

Unit 2140 pass, integration 195 pass, lint clean.
